### PR TITLE
Fix typo in `SetupNewProposer.s.sol`

### DIFF
--- a/setup-templates/template-incident/script/SetupNewProposer.s.sol
+++ b/setup-templates/template-incident/script/SetupNewProposer.s.sol
@@ -22,7 +22,7 @@ contract SetupNewProposer is Script {
         console.log(oldProposer);
         console.log(NEW_PROPOSER);
 
-        // Deploy L2OutputOracle new implementation wiht the new submission interval
+        // Deploy L2OutputOracle new implementation with the new submission interval
         vm.broadcast(DEPLOYER);
         L2OutputOracle l2OutputOracleImpl = new L2OutputOracle({
             _submissionInterval: oldSubmissionInterval,


### PR DESCRIPTION
### Title
Fix typo in `SetupNewProposer.s.sol`

### Description
This pull request fixes a typo in the `SetupNewProposer.s.sol` file. The word "wiht" has been corrected to "with."

### Changes
- Corrected the typo in the comment: "Deploy L2OutputOracle new implementation wiht the new submission interval" to "Deploy L2OutputOracle new implementation with the new submission interval."

### Impact
This is a documentation fix and does not affect the functionality of the code.
