### PR TITLE
Fix Typos and Improve Readability in Deployment Scripts and Logs

### DIFF
--- a/goerli-alpha/2023-08-15-support-eas/Makefile
+++ b/goerli-alpha/2023-08-15-support-eas/Makefile
@@ -28,7 +28,7 @@ sign-cb:
 	--sig "sign(address)" $(CB_SAFE_ADDR)
 
 ##
-# Commands for faciliators to run to test the nested safe
+# Commands for facilitators to run to test the nested safe
 ##
 
 .PHONY: approve-op

--- a/goerli/2023-06-13-l2-upgrades/Makefile
+++ b/goerli/2023-06-13-l2-upgrades/Makefile
@@ -12,7 +12,7 @@ deploy-l2:
 	jq --sort-keys . unsortedl2Impls.json > inputs/addresses-l2.json && \
 	rm unsortedl2Impls.json
 
-etherscan-verifiy-l2-bedrock-implementations:
+etherscan-verify-l2-bedrock-implementations:
 	forge verify-contract $(BASE_FEE_VAULT) BaseFeeVault --constructor-args $(shell cast abi-encode "constructor(address,uint256,uint8)" 0x0b933fFD030d2679986560C414d26093b9d3130F 0x1bc16d674ec80000 1) --verifier ${VERIFIER} --watch --chain-id $(L2_CHAIN_ID)  --verifier-url ${VERIFIER_URL} --compiler-version v0.8.15+commit.e14f2714 --num-of-optimizations=99999 --retries=1
 	forge verify-contract ${GAS_PRICE_ORACLE} GasPriceOracle --verifier ${VERIFIER} --watch --chain-id $(L2_CHAIN_ID) --verifier-url ${VERIFIER_URL} --compiler-version v0.8.15+commit.e14f2714 --num-of-optimizations=99999 --retries=1
 	forge verify-contract ${L1_BLOCK} L1Block --verifier ${VERIFIER} --watch --chain-id $(L2_CHAIN_ID)  --verifier-url ${VERIFIER_URL} --compiler-version v0.8.15+commit.e14f2714 --num-of-optimizations=99999 --retries=1

--- a/mainnet/2024-06-28-update-gas-config/script/RollbackGasConfig.sol
+++ b/mainnet/2024-06-28-update-gas-config/script/RollbackGasConfig.sol
@@ -50,7 +50,7 @@ contract RollbackGasConfig is MultisigBuilder {
     function _getNonce(IGnosisSafe safe) internal view override returns (uint256 nonce) {
         uint256 _nonce = safe.nonce();
         console.log("Safe current nonce:", _nonce);
-        console.log("Incrememnting by 1 to account for planned `Update` tx");
+        console.log("Incrementing by 1 to account for planned `Update` tx");
         return _nonce + 1;
     }
 

--- a/setup-templates/template-incident/script/SetupNewProposer.s.sol
+++ b/setup-templates/template-incident/script/SetupNewProposer.s.sol
@@ -22,7 +22,7 @@ contract SetupNewProposer is Script {
         console.log(oldProposer);
         console.log(NEW_PROPOSER);
 
-        // Deploy L2OutputOracle new implementation wiht the new submission interval
+        // Deploy L2OutputOracle new implementation with the new submission interval
         vm.broadcast(DEPLOYER);
         L2OutputOracle l2OutputOracleImpl = new L2OutputOracle({
             _submissionInterval: oldSubmissionInterval,


### PR DESCRIPTION
Fixed a typo in the script name

Before: etherscan-verifiy-l2-bedrock-implementations:
After: etherscan-verify-l2-bedrock-implementations:
Reason: The word "verifiy" was misspelled. Correcting it to "verify" ensures proper command execution.
Corrected a typo in a logging statement

Before: console.log("Incrememnting by 1 to account for planned \Update` tx");`
After: console.log("Incrementing by 1 to account for planned \Update` tx");`
Reason: The word "Incrememnting" was misspelled. Fixing this improves readability and ensures clarity in logs.
Fixed a typo in a comment regarding L2OutputOracle deployment

Before: // Deploy L2OutputOracle new implementation wiht the new submission interval
After: // Deploy L2OutputOracle new implementation with the new submission interval
Reason: The word "wiht" was misspelled. Correcting it to "with" ensures the comment is clear.
Fixed a typo in a facilitator command description

Before: # Commands for faciliators to run to test the nested safe
After: # Commands for facilitators to run to test the nested safe
Reason: The word "faciliators" was misspelled. The correct spelling is "facilitators."
