### PR TITLE
Enforce postChecks in CI

### DIFF
--- a/.github/workflows/check-post-check.yml
+++ b/.github/workflows/check-post-check.yml
@@ -1,0 +1,52 @@
+name: Check Post-Check Implementation
+
+on:
+  pull_request:
+    paths:
+      - "**/*.sol"
+
+jobs:
+  check-post-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Foundry
+        run: |
+          curl -L https://foundry.paradigm.xyz | bash
+          ~/.foundry/bin/foundryup
+
+      - name: Install dependencies
+        run: |
+          make install-foundry
+
+      - name: Check for _postCheck implementation
+        run: |
+          # Get all Solidity files that have been modified or added in the PR
+          FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep '\.sol$')
+
+          # Initialize error flag
+          ERROR=0
+
+          for file in $FILES; do
+            # Skip if file doesn't exist (was deleted)
+            if [ ! -f "$file" ]; then
+              continue
+            fi
+            
+            # Check if file is in script directory
+            if [[ $file == *"/script/"* ]]; then
+              # Check if _postCheck function is implemented
+              if ! grep -q "function _postCheck" "$file"; then
+                echo "❌ Error: $file is missing the required _postCheck function implementation"
+                ERROR=1
+              fi
+            fi
+          done
+
+          if [ $ERROR -eq 1 ]; then
+            echo "::error::Some script files are missing the required _postCheck function implementation"
+            exit 1
+          fi
+
+          echo "✅ All script files properly implement the _postCheck function"

--- a/.github/workflows/check-post-check.yml
+++ b/.github/workflows/check-post-check.yml
@@ -12,11 +12,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Fetch base branch
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
 
       - name: Check for _postCheck implementation
         run: |
           # Get all Solidity files that have been modified or added in the PR
-          FILES=$(git diff --name-only HEAD^1 HEAD | grep '\.sol$')
+          FILES=$(git diff --name-only --diff-filter=AMR ${{ github.event.pull_request.base.ref }} | grep '\.sol$')
 
           # Initialize error flag
           ERROR=0
@@ -27,11 +32,20 @@ jobs:
               continue
             fi
             
-            # Check if _postCheck function is implemented
-            if ! grep -q "function _postCheck" "$file"; then
+            # Create a temporary file with comments removed
+            # This removes both single-line and multi-line comments
+            sed -E '/\/\*/,/\*\//d' "$file" | sed '/\/\//d' > "${file}.tmp"
+            
+            # Check if _postCheck function is properly implemented (not in comments)
+            # Look for a line that starts with "function _postCheck" (ignoring whitespace)
+            # and contains an opening brace anywhere after it
+            if ! grep -A10 -E '^\s*function\s+_postCheck' "${file}.tmp" | grep -q '{'; then
               echo "❌ Error: $file is missing the required _postCheck function implementation"
               ERROR=1
             fi
+            
+            # Clean up temporary file
+            rm "${file}.tmp"
           done
 
           if [ $ERROR -eq 1 ]; then

--- a/.github/workflows/check-post-check.yml
+++ b/.github/workflows/check-post-check.yml
@@ -10,20 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Foundry
-        run: |
-          curl -L https://foundry.paradigm.xyz | bash
-          ~/.foundry/bin/foundryup
-
-      - name: Install dependencies
-        run: |
-          make install-foundry
+        with:
+          fetch-depth: 2
 
       - name: Check for _postCheck implementation
         run: |
           # Get all Solidity files that have been modified or added in the PR
-          FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep '\.sol$')
+          FILES=$(git diff --name-only HEAD^1 HEAD | grep '\.sol$')
 
           # Initialize error flag
           ERROR=0
@@ -34,13 +27,10 @@ jobs:
               continue
             fi
             
-            # Check if file is in script directory
-            if [[ $file == *"/script/"* ]]; then
-              # Check if _postCheck function is implemented
-              if ! grep -q "function _postCheck" "$file"; then
-                echo "❌ Error: $file is missing the required _postCheck function implementation"
-                ERROR=1
-              fi
+            # Check if _postCheck function is implemented
+            if ! grep -q "function _postCheck" "$file"; then
+              echo "❌ Error: $file is missing the required _postCheck function implementation"
+              ERROR=1
             fi
           done
 


### PR DESCRIPTION
Adds a GitHub action that scans changed files in pull requests and enforces that all solidity scripts must have a `_postCheck` function