### PR TITLE
Bump to eip712sign v0.0.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ deps: install-eip712sign clean-lib forge-deps checkout-op-commit checkout-base-c
 
 .PHONY: install-eip712sign
 install-eip712sign:
-	go install github.com/base-org/eip712sign@v0.0.10
+	go install github.com/base/eip712sign@v0.0.11
 
 .PHONY: clean-lib
 clean-lib:


### PR DESCRIPTION
Bumps the eip712sign version to the latest version (`v0.0.11`), which upgrades the go-ethereum version to `v1.15.6`.