### PR TITLE
bug: Allow disabling validation github action

### DIFF
--- a/.github/workflows/validate-structure.yml
+++ b/.github/workflows/validate-structure.yml
@@ -77,5 +77,7 @@ jobs:
 
             Please check the CI logs above for specific error details and fix the issues before merging.
 
-            📖 See the [validation documentation](docs/folder-format.md) for more details.`
+            📖 See the [validation documentation](docs/folder-format.md) for more details.
+
+            To disable the validation check please add a validation.yml file to your upgrade folder with 'disabled': true`
           })

--- a/validation-tool-interface/package-lock.json
+++ b/validation-tool-interface/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "next": "^14.2.30",
         "react": "^18.2.0",
+        "yaml": "^2.8.1",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -10025,6 +10026,17 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/validation-tool-interface/package.json
+++ b/validation-tool-interface/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "next": "^14.2.30",
     "react": "^18.2.0",
+    "yaml": "^2.8.1",
     "zod": "^3.22.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR allows the ability for developers to add a `validation.yml` file to their tasks with a
```
disabled: true
```
key. This will short circuit the validation check from failing a PR