### PR TITLE
docs: align README with task-local workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Task writing:
   - Good: `pragma solidity 0.8.15`
   - Bad: `pragma solidity ^0.8.20`
 - Always use "onchain" instead of "on-chain"
+- Do not artificially wrap Markdown prose; keep each paragraph and list item on one logical line
 - Config values loaded from a `.env` should be stored as immutable variables in the solidity script(s)
 - We only need task origin validation for mainnet scripts that go through proxy admin owner
 - `RECORD_STATE_DIFF=true` is needed in the task `.env` file in order for the signer tool to work

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 This repo contains execution code and artifacts related to Base contract deployments, upgrades, and calls. For actual contract implementations, see
 [base/contracts](https://github.com/base/contracts).
 
-Active EVM tasks live under `active/evm/tasks/`. Shared network configuration lives under `config/`, and completed historical tasks live under `archive/`.
+Active EVM tasks live under `active/evm/tasks/`. Shared network configuration lives under `config/`, and completed historical tasks live under
+`archive/`.
 
 <!-- Badge row 1 - status -->
 
@@ -18,7 +19,8 @@ Active EVM tasks live under `active/evm/tasks/`. Shared network configuration li
 <!-- Badge row 2 - links and profiles -->
 
 [![Website base.org](https://img.shields.io/website-up-down-green-red/https/base.org.svg)](https://base.org)
-[![Blog](https://img.shields.io/badge/blog-up-green)](https://base.mirror.xyz/) [![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.base.org/)
+[![Blog](https://img.shields.io/badge/blog-up-green)](https://base.mirror.xyz/)
+[![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.base.org/)
 [![Discord](https://img.shields.io/discord/1067165013397213286?label=discord)](https://base.org/discord)
 [![Twitter BuildOnBase](https://img.shields.io/twitter/follow/BuildOnBase?style=social)](https://x.com/BuildOnBase)
 
@@ -31,19 +33,21 @@ Active EVM tasks live under `active/evm/tasks/`. Shared network configuration li
 
 ### Toolchain (mise)
 
-All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every contributor — and especially every signer — runs identical versions. This
-eliminates a class of bugs where domain separators, build artifacts, or generated signatures differ between machines.
+All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every contributor — and especially every signer — runs
+identical versions. This eliminates a class of bugs where domain separators, build artifacts, or generated signatures differ between machines.
 
 **Signers and facilitators don't need to install anything.** `make sign-task` (and `make deps`, `make execute`, etc.) automatically:
 
-1. Installs [`mise`](https://mise.jdx.dev) to `~/.local/bin/mise` if it's not already present, using the vendored installer at [`scripts/install-mise.sh`](scripts/install-mise.sh).
+1. Installs [`mise`](https://mise.jdx.dev) to `~/.local/bin/mise` if it's not already present, using the vendored installer at
+   [`scripts/install-mise.sh`](scripts/install-mise.sh).
 2. Trusts the repo's `mise.toml` and runs `mise install` to fetch the pinned `foundry`, `node`, `bun`, and `go` versions.
-3. Invokes every toolchain command through `mise exec --`, so the pinned versions are used without modifying your shell environment or `PATH`. This deliberately avoids conflicts
-   with any existing `foundryup` or system-level installs.
+3. Invokes every toolchain command through `mise exec --`, so the pinned versions are used without modifying your shell environment or `PATH`. This
+   deliberately avoids conflicts with any existing `foundryup` or system-level installs.
 
-> **Important — `mise` must be on your PATH for the signer-tool.** The generated validation files contain a `cmd` field with `mise exec --` (deliberately, so the JSON is portable
-> across machines), and the signer-tool re-executes that command in a fresh shell. If `mise` is not on your PATH, that subprocess will fail with "command not found".
-> `make bootstrap-mise` will warn you if this is the case. To fix it, add this to your shell config (e.g. `~/.zshrc` or `~/.bashrc`) and restart your shell:
+> **Important — `mise` must be on your PATH for the signer-tool.** The generated validation files contain a `cmd` field with `mise exec --`
+> (deliberately, so the JSON is portable across machines), and the signer-tool re-executes that command in a fresh shell. If `mise` is not on your
+> PATH, that subprocess will fail with "command not found". `make bootstrap-mise` will warn you if this is the case. To fix it, add this to your shell
+> config (e.g. `~/.zshrc` or `~/.bashrc`) and restart your shell:
 >
 > ```bash
 > export PATH="$HOME/.local/bin:$PATH"
@@ -63,8 +67,8 @@ The `Commit SHA` is the source of truth — it must match the commit pinned in `
 
 #### For contributors authoring new tasks (optional)
 
-If you want bare `forge`/`cast`/`bun`/`go` invocations in your interactive shell to resolve to the pinned versions while you're working inside this repo, add mise's shell hook to
-your shell config:
+If you want bare `forge`/`cast`/`bun`/`go` invocations in your interactive shell to resolve to the pinned versions while you're working inside this
+repo, add mise's shell hook to your shell config:
 
 ```bash
 # zsh
@@ -89,8 +93,8 @@ Signers run `make sign-task` from the repository root, select the network and ta
 
 ## Network configuration
 
-Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and `config/zeronet.env`. Task Makefiles include the appropriate shared file and load operation-specific
-values from `config/<network>/.env` inside the task.
+Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and `config/zeronet.env`. Task Makefiles include the appropriate shared file
+and load operation-specific values from `config/<network>/.env` inside the task.
 
 The network `.env` files contain:
 
@@ -99,15 +103,16 @@ The network `.env` files contain:
 - **L1 contract addresses** — proxy admin, bridges, dispute game factories, system config, etc.
 - **L2 contract addresses** — fee vaults, cross-domain messenger, standard bridge, etc.
 
-All address variables are prefixed with `export` so they are available to child shell processes (Forge scripts, shell commands, etc.). Foundry scripts can access them via
-`vm.envAddress("VARIABLE_NAME")`.
+All address variables are prefixed with `export` so they are available to child shell processes (Forge scripts, shell commands, etc.). Foundry scripts
+can access them via `vm.envAddress("VARIABLE_NAME")`.
 
-> **Note:** Update `config/<network>.env` when a known shared address changes. Keep task-specific values, including `BASE_CONTRACTS_COMMIT`, in the task `.env`.
+> **Note:** Update `config/<network>.env` when a known shared address changes. Keep task-specific values, including `BASE_CONTRACTS_COMMIT`, in the
+> task `.env`.
 
 ## Directory structure
 
-Active EVM tasks use one shared Foundry project. Dependencies and reusable Solidity are shared; Make targets, configuration, documentation, signatures, and execution records stay
-with each task:
+Active EVM tasks use one shared Foundry project. Dependencies and reusable Solidity are shared; Make targets, configuration, documentation,
+signatures, and execution records stay with each task:
 
 ```text
 active/evm/
@@ -130,8 +135,8 @@ active/evm/
         └── <script>/<chain-id>/ # Forge broadcast records after execution
 ```
 
-Task commands run from `active/evm/tasks/<task-id>`. The task Makefile installs dependencies and runs Forge against the shared `active/evm` project. Reusable scripts are documented
-in [`active/evm/script/common/README.md`](active/evm/script/common/README.md).
+Task commands run from `active/evm/tasks/<task-id>`. The task Makefile installs dependencies and runs Forge against the shared `active/evm` project.
+Reusable scripts are documented in [`active/evm/script/common/README.md`](active/evm/script/common/README.md).
 
 To install dependencies for the shared project without selecting a task, invoke the root Makefile with a project directory and explicit commit:
 
@@ -159,10 +164,10 @@ A GitHub Actions workflow automatically validates the shared `active/evm` script
 
 **How it works:**
 
-- All tooling (Foundry, Node, Bun, Go) is installed by the [`jdx/mise-action`](https://github.com/jdx/mise-action) GitHub Action using the versions pinned in
-  [`mise.toml`](mise.toml), so CI matches local signer environments.
-- `make deps PROJECT_DIR="$PWD/active/evm"` installs dependencies into the shared `active/evm` Foundry project. `BASE_CONTRACTS_COMMIT` is supplied via the workflow's `env` block,
-  since the shared project has no task `.env` of its own.
+- All tooling (Foundry, Node, Bun, Go) is installed by the [`jdx/mise-action`](https://github.com/jdx/mise-action) GitHub Action using the versions
+  pinned in [`mise.toml`](mise.toml), so CI matches local signer environments.
+- `make deps PROJECT_DIR="$PWD/active/evm"` installs dependencies into the shared `active/evm` Foundry project. `BASE_CONTRACTS_COMMIT` is supplied
+  via the workflow's `env` block, since the shared project has no task `.env` of its own.
 - `forge fmt --check` and `forge build` then run in `active/evm` against the shared `foundry.toml` and `script/common/`.
 
 **What CI does NOT do:**
@@ -204,20 +209,21 @@ RPC_URL := $(L1_RPC_URL)       # or $(L2_RPC_URL)
 SCRIPT_NAME := script/common/<category>/<script>.s.sol:<contract>
 ```
 
-Tasks that generate validation files should use `GEN_VALIDATION` with the `deps-signer-tool` prerequisite, which checks out and installs the signer tool:
+Tasks that generate validation files should use `GEN_VALIDATION` with the `deps-signer-tool` prerequisite, which checks out and installs the signer
+tool:
 
 ```makefile
 gen-validation: validate-config deps-signer-tool
 	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),base-signer.json,)
 ```
 
-Task Makefiles should use these macros rather than inline `forge script` or signer-tool invocations. A task that intentionally pre-signs several future nonces may keep its
-specialized `eip712sign` loop locally; approvals and execution should still use the shared macros.
+Task Makefiles should use these macros rather than inline `forge script` or signer-tool invocations. A task that intentionally pre-signs several
+future nonces may keep its specialized `eip712sign` loop locally; approvals and execution should still use the shared macros.
 
 ## Task origin signing
 
-The root Makefile provides three targets for generating cryptographic attestations that prove who created and facilitated a task. Active task Makefiles inherit them by including
-the root Makefile.
+The root Makefile provides three targets for generating cryptographic attestations that prove who created and facilitated a task. Active task
+Makefiles inherit them by including the root Makefile.
 
 | Target                          | Purpose                                         |
 | ------------------------------- | ----------------------------------------------- |
@@ -225,15 +231,18 @@ the root Makefile.
 | `make sign-as-base-facilitator` | Attest Base team facilitation                   |
 | `make sign-as-sc-facilitator`   | Attest Security Council facilitation            |
 
-Legacy task Makefiles may use the root defaults below. Active task Makefiles override them so the task configuration is signed while signatures remain outside the signed payload:
+Legacy task Makefiles may use the root defaults below. Active task Makefiles override them so the task configuration is signed while signatures remain
+outside the signed payload:
 
 | Variable        | Default                                    | Description                           |
 | --------------- | ------------------------------------------ | ------------------------------------- |
 | `TASK_NAME`     | `$(notdir $(CURDIR))` (directory basename) | Name used to locate signature dir     |
 | `SIGNATURE_DIR` | `$(CURDIR)/../signatures/$(TASK_NAME)`     | Directory where signatures are stored |
 
-All three targets depend on `deps-signer-tool`, which checks out and installs the [task-signing-tool](https://github.com/base/task-signing-tool) automatically.
+All three targets depend on `deps-signer-tool`, which checks out and installs the [task-signing-tool](https://github.com/base/task-signing-tool)
+automatically.
 
-For active EVM tasks, `TASK_ORIGIN_DIR` is `active/evm/tasks/<task-id>/config/<network>` and `SIGNATURE_DIR` is `active/evm/tasks/<task-id>/signatures/<network>`. Keeping
-signatures outside the config directory means generating them does not change the signed payload. Task-origin validation is required for mainnet scripts executed through the proxy
-admin owner. Other tasks, such as Zeronet tasks, may set `skipTaskOriginValidation: true` in each validation file.
+For active EVM tasks, `TASK_ORIGIN_DIR` is `active/evm/tasks/<task-id>/config/<network>` and `SIGNATURE_DIR` is
+`active/evm/tasks/<task-id>/signatures/<network>`. Keeping signatures outside the config directory means generating them does not change the signed
+payload. Task-origin validation is required for mainnet scripts executed through the proxy admin owner. Other tasks, such as Zeronet tasks, may set
+`skipTaskOriginValidation: true` in each validation file.

--- a/README.md
+++ b/README.md
@@ -92,24 +92,41 @@ Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and
 `config/<network>/.env` inside the task contains only task-specific values such
 as `BASE_CONTRACTS_COMMIT`.
 
+The shared network files contain:
+
+- **Network metadata** — RPC URLs, chain IDs, and Ledger account index
+- **Admin addresses** — multisigs, proposer, challenger, and batch sender
+- **L1 addresses** — proxy admin, bridges, dispute games, and system config
+- **L2 addresses** — predeploys, bridges, and fee vaults
+
+Address variables are exported so Forge scripts can read them through
+`vm.envAddress`. Update `config/<network>.env` when a known shared address
+changes; keep operation-specific values in the task `.env`.
+
 ## Directory structure
 
-`active/evm` is one shared Foundry project. Common Solidity lives under
-`script/common/`, dependencies are installed into `active/evm/lib`, and each
-task owns its operational files:
+`active/evm` is one shared Foundry project. Common Solidity and dependencies are
+shared, while each task owns its Make targets, documentation, configuration,
+signatures, and execution records:
 
 ```text
 active/evm/
-├── foundry.toml
-├── script/common/
-└── tasks/<YYYY-MM-DD-task-name>/
-    ├── Makefile
-    ├── FACILITATOR.md
-    ├── config/<network>/
-    │   ├── .env
-    │   ├── README.md
-    │   └── validations/
-    └── signatures/<network>/
+├── foundry.toml                  # shared Foundry configuration
+├── lib/                          # generated shared dependencies; not committed
+├── script/
+│   └── common/                   # reusable Solidity operations
+└── tasks/
+    └── <YYYY-MM-DD-task-name>/
+        ├── Makefile              # task dependencies, validation, and execution
+        ├── FACILITATOR.md        # facilitator runbook
+        ├── config/
+        │   └── <network>/
+        │       ├── .env          # task inputs + BASE_CONTRACTS_COMMIT
+        │       ├── README.md     # signer-facing status and instructions
+        │       └── validations/  # generated signer validation JSON
+        ├── signatures/
+        │   └── <network>/        # task-origin signatures when required
+        └── <script>/<chain-id>/  # Forge broadcast records after execution
 ```
 
 Reusable scripts are documented in
@@ -117,7 +134,7 @@ Reusable scripts are documented in
 
 ### Legacy tasks
 
-Each legacy task (under a network directory, or `archive/legacy/`) has a directory structure similar to the following:
+Each task under `archive/legacy/<network>/` has a structure similar to:
 
 - **records/** Foundry will autogenerate files here from running commands
 - **script/** place to store any one-off Foundry scripts
@@ -149,16 +166,63 @@ A GitHub Actions workflow automatically validates the shared `active/evm` script
 
 ## Multisig macro convention
 
-Task Makefiles use the shared macros in [`Multisig.mk`](Multisig.mk) for
-validation generation, nested-Safe approvals, and execution. Tasks running from
-their own directory set `FORGE_WORKDIR` to `active/evm` so Forge uses the shared
-Foundry project and common scripts.
+Task Makefiles use the shared macros in [`Multisig.mk`](Multisig.mk):
+
+| Macro | Purpose | Key arguments |
+| --- | --- | --- |
+| `GEN_VALIDATION` | Generate signer validation JSON | script, Safe path, sender, output, environment |
+| `MULTISIG_APPROVE` | Register an approval through a nested Safe | Safe path, signatures |
+| `MULTISIG_EXECUTE` | Execute after signatures or nested approvals are ready | signatures |
+
+Two helpers cover common task needs:
+
+| Helper | Purpose |
+| --- | --- |
+| `GET_NONCE` | Read the current Safe nonce |
+| `ADDR_UPPER` | Normalize an address for per-Safe environment variables |
+
+A task Makefile includes the root helpers, points dependencies and Forge at the
+shared EVM project, then selects its common script:
+
+```makefile
+include ../../../../Makefile
+include $(REPO_ROOT)/Multisig.mk
+
+PROJECT_DIR := $(abspath ../..)
+FORGE_WORKDIR := $(PROJECT_DIR)
+RPC_URL := $(L1_RPC_URL)
+SCRIPT_NAME := script/common/<category>/<script>.s.sol:<contract>
+```
+
+Validation targets should depend on `deps-signer-tool` and use a simple output
+name such as `base-signer.json`. Tasks that intentionally pre-sign several
+future nonces may keep that specialized `eip712sign` loop locally; approvals
+and execution should still use the shared macros.
 
 ## Task origin signing
 
-The root Makefile provides `sign-as-task-creator`,
-`sign-as-base-facilitator`, and `sign-as-sc-facilitator`. Active task Makefiles
-set `TASK_ORIGIN_DIR` to `config/<network>` and store signatures separately in
-`signatures/<network>` so generating signatures does not change the signed
-payload. Validation files may set `skipTaskOriginValidation: true` where task
-origin validation is not required.
+The root Makefile provides cryptographic attestations showing who created and
+facilitated a task:
+
+| Target | Purpose |
+| --- | --- |
+| `make sign-as-task-creator` | Attest task authorship |
+| `make sign-as-base-facilitator` | Attest Base facilitation |
+| `make sign-as-sc-facilitator` | Attest Security Council facilitation |
+
+Active task Makefiles set:
+
+| Variable | Active-task value |
+| --- | --- |
+| `TASK_ORIGIN_DIR` | `<task>/config/<network>` |
+| `SIGNATURE_DIR` | `<task>/signatures/<network>` |
+
+The config directory is the signed payload. Signatures are stored outside it so
+creating a signature does not change the payload being signed. The three
+targets install the signer-tool dependency automatically and write the creator,
+Base facilitator, or Security Council facilitator signature into
+`SIGNATURE_DIR`.
+
+Task-origin validation is required for mainnet scripts executed through the
+proxy admin owner. Validation files may set `skipTaskOriginValidation: true`
+when it is not required, such as a Zeronet task.

--- a/README.md
+++ b/README.md
@@ -2,52 +2,35 @@
 
 # contract-deployments
 
-This repo contains execution code and artifacts related to Base contract deployments, upgrades, and calls. For actual contract implementations, see
-[base/contracts](https://github.com/base/contracts).
+This repo contains execution code and artifacts related to Base contract deployments, upgrades, and calls. For actual contract implementations, see [base/contracts](https://github.com/base/contracts).
 
-Active EVM tasks live under `active/evm/tasks/`. Shared network configuration lives under `config/`, and completed historical tasks live under
-`archive/`.
+Active EVM tasks live under `active/evm/tasks/`. Shared network configuration lives under `config/`, and completed historical tasks live under `archive/`.
 
 <!-- Badge row 1 - status -->
 
-[![GitHub contributors](https://img.shields.io/github/contributors/base/contract-deployments)](https://github.com/base/contract-deployments/graphs/contributors)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base/contract-deployments)](https://github.com/base/contract-deployments/graphs/contributors)
-[![GitHub Stars](https://img.shields.io/github/stars/base/contract-deployments.svg)](https://github.com/base/contract-deployments/stargazers)
-![GitHub repo size](https://img.shields.io/github/repo-size/base/contract-deployments)
-[![GitHub](https://img.shields.io/github/license/base/contract-deployments?color=blue)](https://github.com/base/contract-deployments/blob/main/LICENSE)
+[![GitHub contributors](https://img.shields.io/github/contributors/base/contract-deployments)](https://github.com/base/contract-deployments/graphs/contributors) [![GitHub commit activity](https://img.shields.io/github/commit-activity/w/base/contract-deployments)](https://github.com/base/contract-deployments/graphs/contributors) [![GitHub Stars](https://img.shields.io/github/stars/base/contract-deployments.svg)](https://github.com/base/contract-deployments/stargazers) ![GitHub repo size](https://img.shields.io/github/repo-size/base/contract-deployments) [![GitHub](https://img.shields.io/github/license/base/contract-deployments?color=blue)](https://github.com/base/contract-deployments/blob/main/LICENSE)
 
 <!-- Badge row 2 - links and profiles -->
 
-[![Website base.org](https://img.shields.io/website-up-down-green-red/https/base.org.svg)](https://base.org)
-[![Blog](https://img.shields.io/badge/blog-up-green)](https://base.mirror.xyz/)
-[![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.base.org/)
-[![Discord](https://img.shields.io/discord/1067165013397213286?label=discord)](https://base.org/discord)
-[![Twitter BuildOnBase](https://img.shields.io/twitter/follow/BuildOnBase?style=social)](https://x.com/BuildOnBase)
+[![Website base.org](https://img.shields.io/website-up-down-green-red/https/base.org.svg)](https://base.org) [![Blog](https://img.shields.io/badge/blog-up-green)](https://base.mirror.xyz/) [![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.base.org/) [![Discord](https://img.shields.io/discord/1067165013397213286?label=discord)](https://base.org/discord) [![Twitter BuildOnBase](https://img.shields.io/twitter/follow/BuildOnBase?style=social)](https://x.com/BuildOnBase)
 
 <!-- Badge row 3 - detailed status -->
 
-[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base/contract-deployments)](https://github.com/base/contract-deployments/pulls)
-[![GitHub Issues](https://img.shields.io/github/issues-raw/base/contract-deployments.svg)](https://github.com/base/contract-deployments/issues)
+[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr-raw/base/contract-deployments)](https://github.com/base/contract-deployments/pulls) [![GitHub Issues](https://img.shields.io/github/issues-raw/base/contract-deployments.svg)](https://github.com/base/contract-deployments/issues)
 
 ## Setup
 
 ### Toolchain (mise)
 
-All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every contributor — and especially every signer —
-runs identical versions. This eliminates a class of bugs where domain separators, build artifacts, or generated signatures differ between machines.
+All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every contributor — and especially every signer — runs identical versions. This eliminates a class of bugs where domain separators, build artifacts, or generated signatures differ between machines.
 
 **Signers and facilitators don't need to install anything.** `make sign-task` (and `make deps`, `make execute`, etc.) automatically:
 
-1. Installs [`mise`](https://mise.jdx.dev) to `~/.local/bin/mise` if it's not already present, using the vendored installer at
-   [`scripts/install-mise.sh`](scripts/install-mise.sh).
+1. Installs [`mise`](https://mise.jdx.dev) to `~/.local/bin/mise` if it's not already present, using the vendored installer at [`scripts/install-mise.sh`](scripts/install-mise.sh).
 2. Trusts the repo's `mise.toml` and runs `mise install` to fetch the pinned `foundry`, `node`, `bun`, and `go` versions.
-3. Invokes every toolchain command through `mise exec --`, so the pinned versions are used without modifying your shell environment or `PATH`. This
-   deliberately avoids conflicts with any existing `foundryup` or system-level installs.
+3. Invokes every toolchain command through `mise exec --`, so the pinned versions are used without modifying your shell environment or `PATH`. This deliberately avoids conflicts with any existing `foundryup` or system-level installs.
 
-> **Important — `mise` must be on your PATH for the signer-tool.** The generated validation files contain a `cmd` field with `mise exec --`
-> (deliberately, so the JSON is portable across machines), and the signer-tool re-executes that command in a fresh shell. If `mise` is not on your
-> PATH, that subprocess will fail with "command not found". `make bootstrap-mise` will warn you if this is the case. To fix it, add this to your shell
-> config (e.g. `~/.zshrc` or `~/.bashrc`) and restart your shell:
+> **Important — `mise` must be on your PATH for the signer-tool.** The generated validation files contain a `cmd` field with `mise exec --` (deliberately, so the JSON is portable across machines), and the signer-tool re-executes that command in a fresh shell. If `mise` is not on your PATH, that subprocess will fail with "command not found". `make bootstrap-mise` will warn you if this is the case. To fix it, add this to your shell config (e.g. `~/.zshrc` or `~/.bashrc`) and restart your shell:
 >
 > ```bash
 > export PATH="$HOME/.local/bin:$PATH"
@@ -67,8 +50,7 @@ The `Commit SHA` is the source of truth — it must match the commit pinned in `
 
 #### For contributors authoring new tasks (optional)
 
-If you want bare `forge`/`cast`/`bun`/`go` invocations in your interactive shell to resolve to the pinned versions while you're working inside this
-repo, add mise's shell hook to your shell config:
+If you want bare `forge`/`cast`/`bun`/`go` invocations in your interactive shell to resolve to the pinned versions while you're working inside this repo, add mise's shell hook to your shell config:
 
 ```bash
 # zsh
@@ -93,8 +75,7 @@ Signers run `make sign-task` from the repository root, select the network and ta
 
 ## Network configuration
 
-Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and `config/zeronet.env`. Task Makefiles include the appropriate shared file
-and load operation-specific values from `config/<network>/.env` inside the task.
+Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and `config/zeronet.env`. Task Makefiles include the appropriate shared file and load operation-specific values from `config/<network>/.env` inside the task.
 
 The network `.env` files contain:
 
@@ -103,16 +84,13 @@ The network `.env` files contain:
 - **L1 contract addresses** — proxy admin, bridges, dispute game factories, system config, etc.
 - **L2 contract addresses** — fee vaults, cross-domain messenger, standard bridge, etc.
 
-All address variables are prefixed with `export` so they are available to child shell processes (Forge scripts, shell commands, etc.). Foundry scripts
-can access them via `vm.envAddress("VARIABLE_NAME")`.
+All address variables are prefixed with `export` so they are available to child shell processes (Forge scripts, shell commands, etc.). Foundry scripts can access them via `vm.envAddress("VARIABLE_NAME")`.
 
-> **Note:** Update `config/<network>.env` when a known shared address changes. Keep task-specific values, including `BASE_CONTRACTS_COMMIT`, in the
-> task `.env`.
+> **Note:** Update `config/<network>.env` when a known shared address changes. Keep task-specific values, including `BASE_CONTRACTS_COMMIT`, in the task `.env`.
 
 ## Directory structure
 
-Active EVM tasks use one shared Foundry project. Dependencies and reusable Solidity are shared; Make targets, configuration, documentation,
-signatures, and execution records stay with each task:
+Active EVM tasks use one shared Foundry project. Dependencies and reusable Solidity are shared; Make targets, configuration, documentation, signatures, and execution records stay with each task:
 
 ```text
 active/evm/
@@ -135,8 +113,7 @@ active/evm/
         └── <script>/<chain-id>/ # Forge broadcast records after execution
 ```
 
-Task commands run from `active/evm/tasks/<task-id>`. The task Makefile installs dependencies and runs Forge against the shared `active/evm` project.
-Reusable scripts are documented in [`active/evm/script/common/README.md`](active/evm/script/common/README.md).
+Task commands run from `active/evm/tasks/<task-id>`. The task Makefile installs dependencies and runs Forge against the shared `active/evm` project. Reusable scripts are documented in [`active/evm/script/common/README.md`](active/evm/script/common/README.md).
 
 To install dependencies for the shared project without selecting a task, invoke the root Makefile with a project directory and explicit commit:
 
@@ -164,10 +141,8 @@ A GitHub Actions workflow automatically validates the shared `active/evm` script
 
 **How it works:**
 
-- All tooling (Foundry, Node, Bun, Go) is installed by the [`jdx/mise-action`](https://github.com/jdx/mise-action) GitHub Action using the versions
-  pinned in [`mise.toml`](mise.toml), so CI matches local signer environments.
-- `make deps PROJECT_DIR="$PWD/active/evm"` installs dependencies into the shared `active/evm` Foundry project. `BASE_CONTRACTS_COMMIT` is supplied
-  via the workflow's `env` block, since the shared project has no task `.env` of its own.
+- All tooling (Foundry, Node, Bun, Go) is installed by the [`jdx/mise-action`](https://github.com/jdx/mise-action) GitHub Action using the versions pinned in [`mise.toml`](mise.toml), so CI matches local signer environments.
+- `make deps PROJECT_DIR="$PWD/active/evm"` installs dependencies into the shared `active/evm` Foundry project. `BASE_CONTRACTS_COMMIT` is supplied via the workflow's `env` block, since the shared project has no task `.env` of its own.
 - `forge fmt --check` and `forge build` then run in `active/evm` against the shared `foundry.toml` and `script/common/`.
 
 **What CI does NOT do:**
@@ -209,21 +184,18 @@ RPC_URL := $(L1_RPC_URL)       # or $(L2_RPC_URL)
 SCRIPT_NAME := script/common/<category>/<script>.s.sol:<contract>
 ```
 
-Tasks that generate validation files should use `GEN_VALIDATION` with the `deps-signer-tool` prerequisite, which checks out and installs the signer
-tool:
+Tasks that generate validation files should use `GEN_VALIDATION` with the `deps-signer-tool` prerequisite, which checks out and installs the signer tool:
 
 ```makefile
 gen-validation: validate-config deps-signer-tool
 	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),base-signer.json,)
 ```
 
-Task Makefiles should use these macros rather than inline `forge script` or signer-tool invocations. A task that intentionally pre-signs several
-future nonces may keep its specialized `eip712sign` loop locally; approvals and execution should still use the shared macros.
+Task Makefiles should use these macros rather than inline `forge script` or signer-tool invocations. A task that intentionally pre-signs several future nonces may keep its specialized `eip712sign` loop locally; approvals and execution should still use the shared macros.
 
 ## Task origin signing
 
-The root Makefile provides three targets for generating cryptographic attestations that prove who created and facilitated a task. Active task
-Makefiles inherit them by including the root Makefile.
+The root Makefile provides three targets for generating cryptographic attestations that prove who created and facilitated a task. Active task Makefiles inherit them by including the root Makefile.
 
 | Target                          | Purpose                                         |
 | ------------------------------- | ----------------------------------------------- |
@@ -231,18 +203,13 @@ Makefiles inherit them by including the root Makefile.
 | `make sign-as-base-facilitator` | Attest Base team facilitation                   |
 | `make sign-as-sc-facilitator`   | Attest Security Council facilitation            |
 
-Legacy task Makefiles may use the root defaults below. Active task Makefiles override them so the task configuration is signed while signatures remain
-outside the signed payload:
+Legacy task Makefiles may use the root defaults below. Active task Makefiles override them so the task configuration is signed while signatures remain outside the signed payload:
 
 | Variable        | Default                                    | Description                           |
 | --------------- | ------------------------------------------ | ------------------------------------- |
 | `TASK_NAME`     | `$(notdir $(CURDIR))` (directory basename) | Name used to locate signature dir     |
 | `SIGNATURE_DIR` | `$(CURDIR)/../signatures/$(TASK_NAME)`     | Directory where signatures are stored |
 
-All three targets depend on `deps-signer-tool`, which checks out and installs the [task-signing-tool](https://github.com/base/task-signing-tool)
-automatically.
+All three targets depend on `deps-signer-tool`, which checks out and installs the [task-signing-tool](https://github.com/base/task-signing-tool) automatically.
 
-For active EVM tasks, `TASK_ORIGIN_DIR` is `active/evm/tasks/<task-id>/config/<network>` and `SIGNATURE_DIR` is
-`active/evm/tasks/<task-id>/signatures/<network>`. Keeping signatures outside the config directory means generating them does not change the signed
-payload. Task-origin validation is required for mainnet scripts executed through the proxy admin owner. Other tasks, such as Zeronet tasks, may set
-`skipTaskOriginValidation: true` in each validation file.
+For active EVM tasks, `TASK_ORIGIN_DIR` is `active/evm/tasks/<task-id>/config/<network>` and `SIGNATURE_DIR` is `active/evm/tasks/<task-id>/signatures/<network>`. Keeping signatures outside the config directory means generating them does not change the signed payload. Task-origin validation is required for mainnet scripts executed through the proxy admin owner. Other tasks, such as Zeronet tasks, may set `skipTaskOriginValidation: true` in each validation file.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repo contains execution code and artifacts related to Base contract deployments, upgrades, and calls. For actual contract implementations, see [base/contracts](https://github.com/base/contracts).
 
-This repo is structured with each network having a high-level directory which contains subdirectories of any "tasks" (contract deployments/calls) that have happened for that network.
+Active EVM tasks live under `active/evm/tasks/`. Shared network configuration lives under `config/`, and completed historical tasks live under `archive/`.
 
 <!-- Badge row 1 - status -->
 
@@ -72,84 +72,48 @@ This is purely a convenience for task authors — `make` targets work correctly 
 
 ### Running a task
 
-To execute a new task, run one of the following commands (depending on the type of change you're making):
+Each active task has its own `Makefile`, signer-facing `README.md`, facilitator
+guide, task configuration, and validation files. Run task commands from that
+task's directory:
 
-- For gas increase tasks: `make setup-gas-increase network=<network>`
-- For combined gas, elasticity, and DA footprint gas scalar tasks: `make setup-gas-and-elasticity-increase network=<network>`
-- For safe management tasks: `make setup-safe-management network=<network>`
-- For funding tasks: `make setup-funding network=<network>`
-- For updating the partner threshold in Base Bridge: `make setup-bridge-partner-threshold network=<network>`
-- For pausing / un-pausing Base Bridge: `make setup-bridge-pause network=<network>`
-- For pausing SuperchainConfig: `make setup-superchain-config-pause network=<network>`
+```bash
+cd active/evm/tasks/<task-id>
+make deps
+make <task-target>
+```
 
-Each `setup-*` command also creates a matching `<network>/signatures/<task-dir-basename>/` directory for [task origin signing](#task-origin-signing). The parent `signatures/` directory is created automatically via `mkdir -p` for networks that do not yet have one.
-
-Next, `cd` into the directory that was created for you and follow the steps listed below for the relevant template.
-
-Please note, for some older tasks (that have not yet been adapted to use the signer tool) you will need to manually create validation file(s) for your task as they are bespoke to each task and therefore not created automatically as a part of the templates. We use one validation Markdown file per multisig involved in the task, so if there's only one multisig involved in your task, then you can simply create a `VALIDATION.md` file at the root of your task containing the validation instructions, while if there are multiple multisigs involved in the task, then create a `validations/` sub-directory at the root of your task containing the corresponding validation Markdown files. If you need examples to work from, you can browse through similar past tasks in this repo and adapt them to your specific task. Also, please note that we have tooling to generate these files (like the `task-signer-tool`) which removes the manual aspect of creating these validation files, we will soon update these instructions to reflect how this process can be automated.
+Signers start the UI from the repository root with `make sign-task`, select the
+network and task, then follow the task README.
 
 ## Network configuration
 
-Each network directory (`mainnet/`, `sepolia/`, `sepolia-alpha/`, `zeronet/`) contains a `.env` file that defines all contract addresses and network metadata for that chain. These variables are automatically available to every task via the `include ../.env` directive in each task's Makefile, so there is no need to manually load addresses in individual tasks or templates.
-
-The network `.env` files contain:
-
-- **Network metadata** — `NETWORK`, `L1_RPC_URL`, `L2_RPC_URL`, `L1_CHAIN_ID`, `L2_CHAIN_ID`, `LEDGER_ACCOUNT`
-- **Admin addresses** — multisig addresses, proposer, challenger, batch sender, etc.
-- **L1 contract addresses** — proxy admin, bridges, dispute game factories, system config, etc.
-- **L2 contract addresses** — fee vaults, cross-domain messenger, standard bridge, etc.
-
-All address variables are prefixed with `export` so they are available to child shell processes (Forge scripts, shell commands, etc.). Foundry scripts can access them via `vm.envAddress("VARIABLE_NAME")`.
-
-> **Note:** If you need to add or update a contract address, edit the corresponding `{network}/.env` file directly. Do not create per-task address definitions unless they are truly task-specific.
+Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and
+`config/zeronet.env`. Task Makefiles include the appropriate shared file, while
+`config/<network>/.env` inside the task contains only task-specific values such
+as `BASE_CONTRACTS_COMMIT`.
 
 ## Directory structure
 
-Active EVM tasks live under `active/evm/`, which is a single shared Foundry
-project rather than a standalone project per task. A single `active/evm/Makefile`
-selects the active task via `TASK_ID` / `TASK_NETWORK`, reusable operation
-scripts are shared across tasks under `script/common/<category>/`, and each task
-directory holds only its own config, docs, and (per-network) validations and
-signatures:
+`active/evm` is one shared Foundry project. Common Solidity lives under
+`script/common/`, dependencies are installed into `active/evm/lib`, and each
+task owns its operational files:
 
 ```text
 active/evm/
-├── Makefile                     # shared; selects the task via TASK_ID / TASK_NETWORK
-├── foundry.toml                 # shared Foundry config (base-contracts v8.2.1)
-├── script/
-│   └── common/                  # reusable scripts, shared across tasks
-│       └── <category>/          # bridge, funding, gas, ownership, safe, superchain, verifier-update
-└── tasks/
-    └── <YYYY-MM-DD-task-name>/
-        ├── FACILITATOR.md
-        ├── config/
-        │   └── <network>/
-        │       ├── .env         # task inputs + BASE_CONTRACTS_COMMIT + RECORD_STATE_DIFF
-        │       ├── network.env  # RPC, chain ids, Safe/contract addresses
-        │       ├── README.md    # status + description (parsed by the signer tool)
-        │       └── validations/ # generated per-signer validation JSON
-        └── signatures/
-            └── <network>/       # task-origin signatures (when required)
+├── foundry.toml
+├── script/common/
+└── tasks/<YYYY-MM-DD-task-name>/
+    ├── Makefile
+    ├── FACILITATOR.md
+    ├── config/<network>/
+    │   ├── .env
+    │   ├── README.md
+    │   └── validations/
+    └── signatures/<network>/
 ```
 
-Task commands run from `active/evm`, selecting the task by `TASK_ID` /
-`TASK_NETWORK` (both default to the current task in the shared `Makefile`), e.g.
-`TASK_ID=<task> TASK_NETWORK=<network> make gen-validation-cb`. The shared
-Makefile runs Forge from `active/evm` using the shared `foundry.toml` and `lib/`,
-while task-specific files are read from `tasks/<task-id>/config/<network>/`.
-Reusable scripts are documented in [`active/evm/script/common/README.md`](active/evm/script/common/README.md);
-put a script under `script/common/<category>/` when it will be reused across
-tasks, and keep one-off task glue out of `common/`.
-
-The shared `active/evm/Makefile` selects a task (via `TASK_ID` / `TASK_NETWORK`)
-and sources that task's `.env` for `BASE_CONTRACTS_COMMIT`. To install
-dependencies for the shared project without selecting a task (e.g. to build the
-common scripts locally), invoke the root Makefile directly with a `PROJECT_DIR`
-override and an explicit `BASE_CONTRACTS_COMMIT`:
-
-```bash
-make deps PROJECT_DIR="$PWD/active/evm" BASE_CONTRACTS_COMMIT=<commit>
-```
+Reusable scripts are documented in
+[`active/evm/script/common/README.md`](active/evm/script/common/README.md).
 
 ### Legacy tasks
 
@@ -185,167 +149,16 @@ A GitHub Actions workflow automatically validates the shared `active/evm` script
 
 ## Multisig macro convention
 
-All task templates use global macros defined in [`Multisig.mk`](Multisig.mk) for multisig operations:
-
-| Macro              | Purpose                                                         | Key arguments                                             |
-| ------------------ | --------------------------------------------------------------- | --------------------------------------------------------- |
-| `MULTISIG_APPROVE` | Approve a transaction (nested safe hierarchy)                   | `(address_list, signatures)`                              |
-| `MULTISIG_EXECUTE` | Execute an approved transaction on-chain                        | `(signatures)`                                            |
-| `GEN_VALIDATION`   | Generate a validation JSON file for signers via the signer-tool | `(script_name, safe_addr, sender, output_file, env_vars)` |
-
-Two helper macros are also available for tasks that need nonce offset calculations or address manipulation:
-
-| Macro        | Purpose                                                    | Key arguments    |
-| ------------ | ---------------------------------------------------------- | ---------------- |
-| `GET_NONCE`  | Fetch the current nonce of a Safe contract on-chain        | `(safe_address)` |
-| `ADDR_UPPER` | Convert an address to uppercase (for env var construction) | `(address)`      |
-
-Signing is handled externally by the [task-signing-tool](https://github.com/base/task-signing-tool).
-
-Every template Makefile should include `Multisig.mk` and define at least two variables for the macros to work:
-
-```makefile
-include ../../Makefile
-include ../../Multisig.mk
-include ../.env
-include .env
-
-RPC_URL = $(L1_RPC_URL)       # or $(L2_RPC_URL)
-SCRIPT_NAME = MyScript         # class name or .sol file path
-```
-
-Templates that generate validation files should use `GEN_VALIDATION` with the `deps-signer-tool` prerequisite (which checks out and installs the signer-tool):
-
-```makefile
-gen-validation: validate-config deps-signer-tool
-	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),base-signer.json,)
-```
-
-Templates should use these macros rather than inline `forge script` / `eip712sign` / `bun run` invocations. The known exceptions are the incident-response pause templates, which pre-sign 20 future nonces in a loop using inline `eip712sign`; only their `execute-*` targets use `MULTISIG_EXECUTE`.
+Task Makefiles use the shared macros in [`Multisig.mk`](Multisig.mk) for
+validation generation, nested-Safe approvals, and execution. Tasks running from
+their own directory set `FORGE_WORKDIR` to `active/evm` so Forge uses the shared
+Foundry project and common scripts.
 
 ## Task origin signing
 
-The root Makefile provides three targets for generating cryptographic attestations (sigstore bundles) that prove who created and facilitated a task. These are inherited by all task Makefiles via `include ../../Makefile`.
-
-| Target                          | Purpose                                         |
-| ------------------------------- | ----------------------------------------------- |
-| `make sign-as-task-creator`     | Attest authorship of the task (run after setup) |
-| `make sign-as-base-facilitator` | Attest Base team facilitation                   |
-| `make sign-as-sc-facilitator`   | Attest Security Council facilitation            |
-
-Signatures are stored in `<network>/signatures/<task-name>/`, where `<task-name>` is auto-derived from the task directory name. This directory is created automatically when you run any `setup-*` target (in both the root and Solana Makefiles), so it is ready for the signing tool when you invoke one of the targets below. Two variables control this behavior and can be overridden in a task's Makefile if the defaults are not appropriate:
-
-| Variable        | Default                                    | Description                           |
-| --------------- | ------------------------------------------ | ------------------------------------- |
-| `TASK_NAME`     | `$(notdir $(CURDIR))` (directory basename) | Name used to locate signature dir     |
-| `SIGNATURE_DIR` | `$(CURDIR)/../signatures/$(TASK_NAME)`     | Directory where signatures are stored |
-
-All three targets depend on `deps-signer-tool`, which checks out and installs the [task-signing-tool](https://github.com/base/task-signing-tool) automatically.
-
-For `active/evm` tasks, the shared Makefile overrides `TASK_ORIGIN_DIR` and `SIGNATURE_DIR`: the signer tool signs over the `active/evm/tasks/<task-id>/config/<network>` directory (`TASK_ORIGIN_DIR`), while the signatures themselves are written to `active/evm/tasks/<task-id>/signatures/<network>/` (`SIGNATURE_DIR`) — outside the signed directory, so generating signatures does not change the signed payload. A task may opt out of task-origin validation entirely by setting `skipTaskOriginValidation: true` at the root of each validation file (e.g. non-production networks such as zeronet).
-
-## Using the gas limit increase template
-
-This template is increasing the throughput on Base Chain.
-
-1. Ensure you have followed the instructions above in `setup`
-1. Go to the folder that was created using the `make setup-gas-increase network=<network>` step
-1. Fill in all TODOs (search for "TODO" in the folder) in the `.env` and `README` files. Tip: you can run `make deps` followed by `make sign-upgrade` to produce a Tenderly simulation which will help fill in several of the TODOs in the README (and also `make sign-rollback`).
-1. Check in the task when it's ready to sign and collect signatures from signers
-1. Once executed, check in the records files and mark the task `EXECUTED` in the README.
-
-## Using the combined gas limit, elasticity, and DA footprint gas scalar template
-
-This template is used to update the gas limit, elasticity, and DA footprint gas scalar, or roll back the changes (if needed).
-
-1. Ensure you have followed the instructions above in `setup`, including running `make setup-gas-and-elasticity-increase network=<network>` and then go to the folder that was created by this command.
-1. Specify the commit of [Base contracts code](https://github.com/base/contracts) in the `.env` file.
-1. Run `make deps`.
-1. Fill in any task-specific variables in the `.env` file that have per-network comments (e.g., `OWNER_SAFE`, `SENDER`), using the value for your target network.
-1. Ensure the `SENDER` variable in the `.env` file is set to a signer of `OWNER_SAFE`.
-1. Set the `FROM_*` and `TO_*` values for gas limit and elasticity in the `.env` file.
-1. Calculate the DA footprint gas scalar using the DA limits runbook at `go/base-da-config`. `make da-scalar TARGET_BLOB_COUNT=<value>` is the source of truth for the standard soft-cap policy and calculates `gas_limit / (elasticity * da_soft_cap_blob_count * 32,000)`. Since BPO2, Base has used a DA soft-cap blob count of 21, passed as `TARGET_BLOB_COUNT=21`, to allow the chain to use all L1 DA before raising the L2 base fee. The command prints the `.env` value and the DA table to copy into the task README. Pass `BUILDER_HARD_CAP=<value>` after checking the target network's `op_batcher_throttle_block_size_upper_limit` Config Service value. The task README includes links for the standard network scopes. Set the `FROM_DA_FOOTPRINT_GAS_SCALAR` and `TO_DA_FOOTPRINT_GAS_SCALAR` values in the `.env` file.
-1. Build the contracts with `forge build`.
-1. Generate the validation file for signers with `make gen-validation`.
-1. Generate the rollback validation file for signers with `make gen-validation-rollback`.
-1. Double check the `cmd` field at the top of both of the generated validation files and ensure that the value passed to the `--sender` flag matches the `SENDER` env var already defined in the `.env` file.
-1. Ensure that all of the fields marked as `TODO` in the tasks's `README.md` have been properly filled out.
-1. Check in the task when it's ready to sign and request the facilitators to collect signatures from signers.
-1. Once executed, check in the records files and mark the task `EXECUTED` in the README.
-
-## Using the safe management template
-
-This template is used to perform ownership management on a Gnosis Safe, like the incident multisig, specifically it can be used to change the owners of the multisig.
-
-1. Ensure you have followed the instructions above in `setup`, including running `make setup-safe-management network=<network>` and go to the folder that was created by this command.
-1. Specify the commit of [Base contracts code](https://github.com/base/contracts) you intend to use in the `.env` file.
-1. Enter the directory that was generated for the task (in the first step) and then run `make deps`.
-1. Specify the `OWNER_SAFE`, which is the safe multisig where an owner will be replaced and the `SENDER` which should be the address of a current signer of the multisig.
-1. Fill in the `OwnerDiff.json` inside the task's directory with the addresses to add to, and remove from, the multisig in their respective fields.
-1. Ensure that the `EXISTING_OWNERS_LENGTH` constant value inside the `script/UpdateSigners.s.sol` script is set appropriately, in particular that it equals the exact number of current members of the Incident Multisig Safe (prior to running the task).
-1. Build the contracts with `forge build`.
-1. Generate the validation file for signers with `make gen-validation`.
-1. Double check the `cmd` field at the top of the generated validation file at `validations/base-signer.json` and ensure that the value passed to the `--sender` flag matches the `SENDER` env var already defined in the `.env` file.
-1. Check in the task when it's ready to sign and request the facilitators to collect signatures from signers.
-1. Once executed, check in the records files and mark the task `EXECUTED` in the README.
-
-## Using the funding template
-
-This template is used to fund addresses from a Gnosis Safe.
-
-1. Ensure you have followed the instructions above in `setup`.
-1. Run `make setup-funding network=<network>` and go to the folder that was created by this command.
-1. Specify the commit of [Base contracts code](https://github.com/base/contracts) you intend to use in the `.env` file.
-1. Run `make deps`.
-1. Specify the `SAFE`, which is the safe that will fund the addresses in the `.env` file.
-1. Specify the `recipients` and `funds` arrays (in 1e18 units) in the `funding.json` file.
-1. Build the contracts with `forge build`.
-1. Simulate the task with `make sign` and update the generic validations in `VALIDATION.md` with the real values.
-1. Check in the task when it's ready to sign and request the facilitators to collect signatures from signers.
-1. Once executed, check in the records files and mark the task `EXECUTED` in the README.
-
-## Using the Base Bridge set partner threshold template
-
-This template is used to update the partner threshold in [Base Bridge](https://github.com/base/bridge), affecting the amount of required partner signatures to approve bridge messages.
-
-1. Ensure you have followed the instructions above in `setup`.
-1. Run `make setup-bridge-partner-threshold network=<network>` and go to the folder that was created by this command.
-1. Specify the commit of [Base contracts code](https://github.com/base/contracts) you intend to use in the `.env` file.
-1. Run `make deps`.
-1. Fill in any task-specific variables in the `.env` file that have per-network comments, using the value for your target network.
-1. Set the `NEW_THRESHOLD` variable in the `.env` file.
-1. Ensure the `--sender` flag in the `make gen-validation` command in the `Makefile` file is set to a signer for `OWNER_SAFE` in `.env`.
-1. Build the contracts with `forge build`.
-1. Generate the validation file for signers with `make gen-validation`.
-1. Check in the task when it's ready to sign and request the facilitators to collect signatures from signers.
-1. Once executed, check in the records files and mark the task `EXECUTED` in the README.
-
-## Using the pause Base Bridge template
-
-This template is used to pause or un-pause [Base Bridge](https://github.com/base/bridge).
-
-1. Ensure you have followed the instructions above in `setup`.
-1. Run `make setup-bridge-pause network=<network>` and go to the folder that was created by this command.
-1. Specify the commit of [Base contracts code](https://github.com/base/contracts) you intend to use in the `.env` file.
-1. Run `make deps`.
-1. Fill in any task-specific variables in the `.env` file that have per-network comments (e.g., `L2_BRIDGE`), using the value for your target network.
-1. Set the `IS_PAUSED` variable to `true` or `false` in the `.env` file depending on if you intend to pause or unpause the bridge.
-1. Ensure the `SENDER` variable in the Makefile is set to a signer for `OWNER_SAFE`.
-1. Build the contracts with `forge build`.
-1. Generate the validation file for signers with `make gen-validation`.
-1. Check in the task when it's ready to sign and request the facilitators to collect signatures from signers.
-1. Once executed, check in the records files and mark the task `EXECUTED` in the README.
-
-## Using the pause SuperchainConfig template
-
-This template is used to pause or un-pause the L1 SuperchainConfig contract.
-
-1. Ensure you have followed the instructions above in `setup`.
-1. Run `make setup-superchain-config-pause network=<network>` and go to the folder that was created by this command.
-1. Specify the commit of [Base contracts code](https://github.com/base/contracts) you intend to use in the `.env` file.
-1. Run `make deps`.
-1. Fill in any task-specific variables in the `.env` file that have per-network comments, using the value for your target network.
-1. Build the contracts with `forge build`.
-1. Sign the pause transaction with `make sign-pause` or generate the validation file for un-pausing with `make gen-validation-unpause`.
-1. Check in the task when it's ready to sign and request the facilitators to collect signatures from signers.
-1. Once executed, check in the records files and mark the task `EXECUTED` in the README.
+The root Makefile provides `sign-as-task-creator`,
+`sign-as-base-facilitator`, and `sign-as-sc-facilitator`. Active task Makefiles
+set `TASK_ORIGIN_DIR` to `config/<network>` and store signatures separately in
+`signatures/<network>` so generating signatures does not change the signed
+payload. Validation files may set `skipTaskOriginValidation: true` where task
+origin validation is not required.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 This repo contains execution code and artifacts related to Base contract deployments, upgrades, and calls. For actual contract implementations, see [base/contracts](https://github.com/base/contracts).
 
-Active EVM tasks live under `active/evm/tasks/`. Shared network configuration lives under `config/`, and completed historical tasks live under `archive/`.
+Active EVM tasks live under `active/evm/tasks/`. Shared network configuration
+lives under `config/`, and completed historical tasks live under `archive/`.
 
 <!-- Badge row 1 - status -->
 
@@ -72,9 +73,8 @@ This is purely a convenience for task authors — `make` targets work correctly 
 
 ### Running a task
 
-Each active task has its own `Makefile`, signer-facing `README.md`, facilitator
-guide, task configuration, and validation files. Run task commands from that
-task's directory:
+Each active task owns its Makefile, signer README, facilitator guide,
+configuration, and validations. Run task commands from the task directory:
 
 ```bash
 cd active/evm/tasks/<task-id>
@@ -82,55 +82,66 @@ make deps
 make <task-target>
 ```
 
-Signers start the UI from the repository root with `make sign-task`, select the
-network and task, then follow the task README.
+Signers run `make sign-task` from the repository root, select the network and
+task in the UI, and follow the task README.
 
 ## Network configuration
 
 Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and
-`config/zeronet.env`. Task Makefiles include the appropriate shared file, while
-`config/<network>/.env` inside the task contains only task-specific values such
-as `BASE_CONTRACTS_COMMIT`.
+`config/zeronet.env`. Task Makefiles include the appropriate shared file and
+load operation-specific values from `config/<network>/.env` inside the task.
 
-The shared network files contain:
+The network `.env` files contain:
 
-- **Network metadata** — RPC URLs, chain IDs, and Ledger account index
-- **Admin addresses** — multisigs, proposer, challenger, and batch sender
-- **L1 addresses** — proxy admin, bridges, dispute games, and system config
-- **L2 addresses** — predeploys, bridges, and fee vaults
+- **Network metadata** — `NETWORK`, `L1_RPC_URL`, `L2_RPC_URL`, `L1_CHAIN_ID`, `L2_CHAIN_ID`, `LEDGER_ACCOUNT`
+- **Admin addresses** — multisig addresses, proposer, challenger, batch sender, etc.
+- **L1 contract addresses** — proxy admin, bridges, dispute game factories, system config, etc.
+- **L2 contract addresses** — fee vaults, cross-domain messenger, standard bridge, etc.
 
-Address variables are exported so Forge scripts can read them through
-`vm.envAddress`. Update `config/<network>.env` when a known shared address
-changes; keep operation-specific values in the task `.env`.
+All address variables are prefixed with `export` so they are available to child shell processes (Forge scripts, shell commands, etc.). Foundry scripts can access them via `vm.envAddress("VARIABLE_NAME")`.
+
+> **Note:** Update `config/<network>.env` when a known shared address changes.
+> Keep task-specific values, including `BASE_CONTRACTS_COMMIT`, in the task
+> `.env`.
 
 ## Directory structure
 
-`active/evm` is one shared Foundry project. Common Solidity and dependencies are
-shared, while each task owns its Make targets, documentation, configuration,
-signatures, and execution records:
+Active EVM tasks use one shared Foundry project. Dependencies and reusable
+Solidity are shared; Make targets, configuration, documentation, signatures,
+and execution records stay with each task:
 
 ```text
 active/evm/
-├── foundry.toml                  # shared Foundry configuration
-├── lib/                          # generated shared dependencies; not committed
+├── foundry.toml                 # shared Foundry config (base-contracts v8.2.1)
+├── lib/                         # generated shared dependencies; not committed
 ├── script/
-│   └── common/                   # reusable Solidity operations
+│   └── common/                  # reusable scripts, shared across tasks
+│       └── <category>/          # bridge, funding, gas, ownership, safe, superchain, verifier-update
 └── tasks/
     └── <YYYY-MM-DD-task-name>/
-        ├── Makefile              # task dependencies, validation, and execution
-        ├── FACILITATOR.md        # facilitator runbook
+        ├── Makefile             # task dependencies, validation, approvals, execution
+        ├── FACILITATOR.md       # facilitator runbook
         ├── config/
         │   └── <network>/
-        │       ├── .env          # task inputs + BASE_CONTRACTS_COMMIT
-        │       ├── README.md     # signer-facing status and instructions
-        │       └── validations/  # generated signer validation JSON
+        │       ├── .env         # task inputs + BASE_CONTRACTS_COMMIT
+        │       ├── README.md    # status + description (parsed by the signer tool)
+        │       └── validations/ # generated per-signer validation JSON
         ├── signatures/
-        │   └── <network>/        # task-origin signatures when required
-        └── <script>/<chain-id>/  # Forge broadcast records after execution
+        │   └── <network>/       # task-origin signatures (when required)
+        └── <script>/<chain-id>/ # Forge broadcast records after execution
 ```
 
-Reusable scripts are documented in
+Task commands run from `active/evm/tasks/<task-id>`. The task Makefile installs
+dependencies and runs Forge against the shared `active/evm` project. Reusable
+scripts are documented in
 [`active/evm/script/common/README.md`](active/evm/script/common/README.md).
+
+To install dependencies for the shared project without selecting a task, invoke
+the root Makefile with a project directory and explicit commit:
+
+```bash
+make deps PROJECT_DIR="$PWD/active/evm" BASE_CONTRACTS_COMMIT=<commit>
+```
 
 ### Legacy tasks
 
@@ -166,23 +177,25 @@ A GitHub Actions workflow automatically validates the shared `active/evm` script
 
 ## Multisig macro convention
 
-Task Makefiles use the shared macros in [`Multisig.mk`](Multisig.mk):
+Task Makefiles use global macros defined in [`Multisig.mk`](Multisig.mk) for multisig operations:
 
-| Macro | Purpose | Key arguments |
-| --- | --- | --- |
-| `GEN_VALIDATION` | Generate signer validation JSON | script, Safe path, sender, output, environment |
-| `MULTISIG_APPROVE` | Register an approval through a nested Safe | Safe path, signatures |
-| `MULTISIG_EXECUTE` | Execute after signatures or nested approvals are ready | signatures |
+| Macro              | Purpose                                                         | Key arguments                                             |
+| ------------------ | --------------------------------------------------------------- | --------------------------------------------------------- |
+| `MULTISIG_APPROVE` | Approve a transaction (nested safe hierarchy)                   | `(address_list, signatures)`                              |
+| `MULTISIG_EXECUTE` | Execute an approved transaction onchain                         | `(signatures)`                                            |
+| `GEN_VALIDATION`   | Generate a validation JSON file for signers via the signer-tool | `(script_name, safe_addr, sender, output_file, env_vars)` |
 
-Two helpers cover common task needs:
+Two helper macros are also available for tasks that need nonce offset calculations or address manipulation:
 
-| Helper | Purpose |
-| --- | --- |
-| `GET_NONCE` | Read the current Safe nonce |
-| `ADDR_UPPER` | Normalize an address for per-Safe environment variables |
+| Macro        | Purpose                                                    | Key arguments    |
+| ------------ | ---------------------------------------------------------- | ---------------- |
+| `GET_NONCE`  | Fetch the current nonce of a Safe contract onchain         | `(safe_address)` |
+| `ADDR_UPPER` | Convert an address to uppercase (for env var construction) | `(address)`      |
 
-A task Makefile includes the root helpers, points dependencies and Forge at the
-shared EVM project, then selects its common script:
+Signing is handled externally by the [task-signing-tool](https://github.com/base/task-signing-tool).
+
+Each task Makefile includes the root helpers, points Forge at the shared EVM
+project, and defines the RPC and script:
 
 ```makefile
 include ../../../../Makefile
@@ -190,39 +203,50 @@ include $(REPO_ROOT)/Multisig.mk
 
 PROJECT_DIR := $(abspath ../..)
 FORGE_WORKDIR := $(PROJECT_DIR)
-RPC_URL := $(L1_RPC_URL)
+RPC_URL := $(L1_RPC_URL)       # or $(L2_RPC_URL)
 SCRIPT_NAME := script/common/<category>/<script>.s.sol:<contract>
 ```
 
-Validation targets should depend on `deps-signer-tool` and use a simple output
-name such as `base-signer.json`. Tasks that intentionally pre-sign several
-future nonces may keep that specialized `eip712sign` loop locally; approvals
-and execution should still use the shared macros.
+Tasks that generate validation files should use `GEN_VALIDATION` with the
+`deps-signer-tool` prerequisite, which checks out and installs the signer tool:
+
+```makefile
+gen-validation: validate-config deps-signer-tool
+	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),base-signer.json,)
+```
+
+Task Makefiles should use these macros rather than inline `forge script` or
+signer-tool invocations. A task that intentionally pre-signs several future
+nonces may keep its specialized `eip712sign` loop locally; approvals and
+execution should still use the shared macros.
 
 ## Task origin signing
 
-The root Makefile provides cryptographic attestations showing who created and
-facilitated a task:
+The root Makefile provides three targets for generating cryptographic
+attestations that prove who created and facilitated a task. Active task
+Makefiles inherit them by including the root Makefile.
 
-| Target | Purpose |
-| --- | --- |
-| `make sign-as-task-creator` | Attest task authorship |
-| `make sign-as-base-facilitator` | Attest Base facilitation |
-| `make sign-as-sc-facilitator` | Attest Security Council facilitation |
+| Target                          | Purpose                                         |
+| ------------------------------- | ----------------------------------------------- |
+| `make sign-as-task-creator`     | Attest authorship of the task (run after setup) |
+| `make sign-as-base-facilitator` | Attest Base team facilitation                   |
+| `make sign-as-sc-facilitator`   | Attest Security Council facilitation            |
 
-Active task Makefiles set:
+Legacy task Makefiles may use the root defaults below. Active task Makefiles
+override them so the task configuration is signed while signatures remain
+outside the signed payload:
 
-| Variable | Active-task value |
-| --- | --- |
-| `TASK_ORIGIN_DIR` | `<task>/config/<network>` |
-| `SIGNATURE_DIR` | `<task>/signatures/<network>` |
+| Variable        | Default                                    | Description                           |
+| --------------- | ------------------------------------------ | ------------------------------------- |
+| `TASK_NAME`     | `$(notdir $(CURDIR))` (directory basename) | Name used to locate signature dir     |
+| `SIGNATURE_DIR` | `$(CURDIR)/../signatures/$(TASK_NAME)`     | Directory where signatures are stored |
 
-The config directory is the signed payload. Signatures are stored outside it so
-creating a signature does not change the payload being signed. The three
-targets install the signer-tool dependency automatically and write the creator,
-Base facilitator, or Security Council facilitator signature into
-`SIGNATURE_DIR`.
+All three targets depend on `deps-signer-tool`, which checks out and installs the [task-signing-tool](https://github.com/base/task-signing-tool) automatically.
 
+For active EVM tasks, `TASK_ORIGIN_DIR` is
+`active/evm/tasks/<task-id>/config/<network>` and `SIGNATURE_DIR` is
+`active/evm/tasks/<task-id>/signatures/<network>`. Keeping signatures outside
+the config directory means generating them does not change the signed payload.
 Task-origin validation is required for mainnet scripts executed through the
-proxy admin owner. Validation files may set `skipTaskOriginValidation: true`
-when it is not required, such as a Zeronet task.
+proxy admin owner. Other tasks, such as Zeronet tasks, may set
+`skipTaskOriginValidation: true` in each validation file.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Active EVM tasks live under `active/evm/tasks/`. Shared network configuration li
 
 ### Toolchain (mise)
 
-All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every contributor — and especially every signer — runs
-identical versions. This eliminates a class of bugs where domain separators, build artifacts, or generated signatures differ between machines.
+All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every contributor — and especially every signer —
+runs identical versions. This eliminates a class of bugs where domain separators, build artifacts, or generated signatures differ between machines.
 
 **Signers and facilitators don't need to install anything.** `make sign-task` (and `make deps`, `make execute`, etc.) automatically:
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # contract-deployments
 
-This repo contains execution code and artifacts related to Base contract deployments, upgrades, and
-calls. For actual contract implementations, see [base/contracts](https://github.com/base/contracts).
+This repo contains execution code and artifacts related to Base contract deployments, upgrades, and calls. For actual contract
+implementations, see [base/contracts](https://github.com/base/contracts).
 
-Active EVM tasks live under `active/evm/tasks/`. Shared network configuration lives under `config/`,
-and completed historical tasks live under `archive/`.
+Active EVM tasks live under `active/evm/tasks/`. Shared network configuration lives under `config/`, and completed historical tasks live
+under `archive/`.
 
 <!-- Badge row 1 - status -->
 
@@ -33,27 +33,22 @@ and completed historical tasks live under `archive/`.
 
 ### Toolchain (mise)
 
-All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every
-contributor — and especially every signer — runs identical versions. This eliminates a class of bugs
-where domain separators, build artifacts, or generated signatures differ between machines.
+All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every contributor — and especially every
+signer — runs identical versions. This eliminates a class of bugs where domain separators, build artifacts, or generated signatures differ
+between machines.
 
-**Signers and facilitators don't need to install anything.** `make sign-task` (and `make deps`,
-`make execute`, etc.) automatically:
+**Signers and facilitators don't need to install anything.** `make sign-task` (and `make deps`, `make execute`, etc.) automatically:
 
-1. Installs [`mise`](https://mise.jdx.dev) to `~/.local/bin/mise` if it's not already present, using
-   the vendored installer at [`scripts/install-mise.sh`](scripts/install-mise.sh).
-2. Trusts the repo's `mise.toml` and runs `mise install` to fetch the pinned `foundry`, `node`,
-   `bun`, and `go` versions.
-3. Invokes every toolchain command through `mise exec --`, so the pinned versions are used without
-   modifying your shell environment or `PATH`. This deliberately avoids conflicts with any existing
-   `foundryup` or system-level installs.
+1. Installs [`mise`](https://mise.jdx.dev) to `~/.local/bin/mise` if it's not already present, using the vendored installer at
+   [`scripts/install-mise.sh`](scripts/install-mise.sh).
+2. Trusts the repo's `mise.toml` and runs `mise install` to fetch the pinned `foundry`, `node`, `bun`, and `go` versions.
+3. Invokes every toolchain command through `mise exec --`, so the pinned versions are used without modifying your shell environment or
+   `PATH`. This deliberately avoids conflicts with any existing `foundryup` or system-level installs.
 
-> **Important — `mise` must be on your PATH for the signer-tool.** The generated validation files
-> contain a `cmd` field with `mise exec --` (deliberately, so the JSON is portable across machines),
-> and the signer-tool re-executes that command in a fresh shell. If `mise` is not on your PATH, that
-> subprocess will fail with "command not found". `make bootstrap-mise` will warn you if this is the
-> case. To fix it, add this to your shell config (e.g. `~/.zshrc` or `~/.bashrc`) and restart your
-> shell:
+> **Important — `mise` must be on your PATH for the signer-tool.** The generated validation files contain a `cmd` field with `mise exec --`
+> (deliberately, so the JSON is portable across machines), and the signer-tool re-executes that command in a fresh shell. If `mise` is not
+> on your PATH, that subprocess will fail with "command not found". `make bootstrap-mise` will warn you if this is the case. To fix it, add
+> this to your shell config (e.g. `~/.zshrc` or `~/.bashrc`) and restart your shell:
 >
 > ```bash
 > export PATH="$HOME/.local/bin:$PATH"
@@ -73,8 +68,8 @@ The `Commit SHA` is the source of truth — it must match the commit pinned in `
 
 #### For contributors authoring new tasks (optional)
 
-If you want bare `forge`/`cast`/`bun`/`go` invocations in your interactive shell to resolve to the
-pinned versions while you're working inside this repo, add mise's shell hook to your shell config:
+If you want bare `forge`/`cast`/`bun`/`go` invocations in your interactive shell to resolve to the pinned versions while you're working
+inside this repo, add mise's shell hook to your shell config:
 
 ```bash
 # zsh
@@ -87,8 +82,8 @@ This is purely a convenience for task authors — `make` targets work correctly 
 
 ### Running a task
 
-Each active task owns its Makefile, signer README, facilitator guide, configuration, and
-validations. Run task commands from the task directory:
+Each active task owns its Makefile, signer README, facilitator guide, configuration, and validations. Run task commands from the task
+directory:
 
 ```bash
 cd active/evm/tasks/<task-id>
@@ -96,34 +91,30 @@ make deps
 make <task-target>
 ```
 
-Signers run `make sign-task` from the repository root, select the network and task in the UI, and
-follow the task README.
+Signers run `make sign-task` from the repository root, select the network and task in the UI, and follow the task README.
 
 ## Network configuration
 
-Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and `config/zeronet.env`.
-Task Makefiles include the appropriate shared file and load operation-specific values from
-`config/<network>/.env` inside the task.
+Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and `config/zeronet.env`. Task Makefiles include the appropriate
+shared file and load operation-specific values from `config/<network>/.env` inside the task.
 
 The network `.env` files contain:
 
-- **Network metadata** — `NETWORK`, `L1_RPC_URL`, `L2_RPC_URL`, `L1_CHAIN_ID`, `L2_CHAIN_ID`,
-  `LEDGER_ACCOUNT`
+- **Network metadata** — `NETWORK`, `L1_RPC_URL`, `L2_RPC_URL`, `L1_CHAIN_ID`, `L2_CHAIN_ID`, `LEDGER_ACCOUNT`
 - **Admin addresses** — multisig addresses, proposer, challenger, batch sender, etc.
 - **L1 contract addresses** — proxy admin, bridges, dispute game factories, system config, etc.
 - **L2 contract addresses** — fee vaults, cross-domain messenger, standard bridge, etc.
 
-All address variables are prefixed with `export` so they are available to child shell processes
-(Forge scripts, shell commands, etc.). Foundry scripts can access them via
-`vm.envAddress("VARIABLE_NAME")`.
+All address variables are prefixed with `export` so they are available to child shell processes (Forge scripts, shell commands, etc.).
+Foundry scripts can access them via `vm.envAddress("VARIABLE_NAME")`.
 
-> **Note:** Update `config/<network>.env` when a known shared address changes. Keep task-specific
-> values, including `BASE_CONTRACTS_COMMIT`, in the task `.env`.
+> **Note:** Update `config/<network>.env` when a known shared address changes. Keep task-specific values, including `BASE_CONTRACTS_COMMIT`,
+> in the task `.env`.
 
 ## Directory structure
 
-Active EVM tasks use one shared Foundry project. Dependencies and reusable Solidity are shared; Make
-targets, configuration, documentation, signatures, and execution records stay with each task:
+Active EVM tasks use one shared Foundry project. Dependencies and reusable Solidity are shared; Make targets, configuration, documentation,
+signatures, and execution records stay with each task:
 
 ```text
 active/evm/
@@ -146,12 +137,11 @@ active/evm/
         └── <script>/<chain-id>/ # Forge broadcast records after execution
 ```
 
-Task commands run from `active/evm/tasks/<task-id>`. The task Makefile installs dependencies and
-runs Forge against the shared `active/evm` project. Reusable scripts are documented in
-[`active/evm/script/common/README.md`](active/evm/script/common/README.md).
+Task commands run from `active/evm/tasks/<task-id>`. The task Makefile installs dependencies and runs Forge against the shared `active/evm`
+project. Reusable scripts are documented in [`active/evm/script/common/README.md`](active/evm/script/common/README.md).
 
-To install dependencies for the shared project without selecting a task, invoke the root Makefile
-with a project directory and explicit commit:
+To install dependencies for the shared project without selecting a task, invoke the root Makefile with a project directory and explicit
+commit:
 
 ```bash
 make deps PROJECT_DIR="$PWD/active/evm" BASE_CONTRACTS_COMMIT=<commit>
@@ -165,30 +155,24 @@ Each task under `archive/legacy/<network>/` has a structure similar to:
 - **script/** place to store any one-off Foundry scripts
 - **src/** place to store any one-off smart contracts (long-lived contracts should go in
   [base/contracts](https://github.com/base/contracts))
-- **.env** place to store task-specific environment variables (contract addresses are inherited from
-  the network-level `.env`)
+- **.env** place to store task-specific environment variables (contract addresses are inherited from the network-level `.env`)
 
 ## CI — Common Script Validation
 
-A GitHub Actions workflow automatically validates the shared `active/evm` scripts on every pull
-request and on pushes to `main`.
+A GitHub Actions workflow automatically validates the shared `active/evm` scripts on every pull request and on pushes to `main`.
 
 **What CI checks:**
 
 1. **Solidity formatting** — `forge fmt --check script/` ensures formatting consistency.
-2. **Compilation** — `forge build` verifies that imports resolve, types are correct, and all
-   dependencies are present.
+2. **Compilation** — `forge build` verifies that imports resolve, types are correct, and all dependencies are present.
 
 **How it works:**
 
-- All tooling (Foundry, Node, Bun, Go) is installed by the
-  [`jdx/mise-action`](https://github.com/jdx/mise-action) GitHub Action using the versions pinned in
-  [`mise.toml`](mise.toml), so CI matches local signer environments.
-- `make deps PROJECT_DIR="$PWD/active/evm"` installs dependencies into the shared `active/evm`
-  Foundry project. `BASE_CONTRACTS_COMMIT` is supplied via the workflow's `env` block, since the
-  shared project has no task `.env` of its own.
-- `forge fmt --check` and `forge build` then run in `active/evm` against the shared `foundry.toml`
-  and `script/common/`.
+- All tooling (Foundry, Node, Bun, Go) is installed by the [`jdx/mise-action`](https://github.com/jdx/mise-action) GitHub Action using the
+  versions pinned in [`mise.toml`](mise.toml), so CI matches local signer environments.
+- `make deps PROJECT_DIR="$PWD/active/evm"` installs dependencies into the shared `active/evm` Foundry project. `BASE_CONTRACTS_COMMIT` is
+  supplied via the workflow's `env` block, since the shared project has no task `.env` of its own.
+- `forge fmt --check` and `forge build` then run in `active/evm` against the shared `foundry.toml` and `script/common/`.
 
 **What CI does NOT do:**
 
@@ -196,9 +180,7 @@ request and on pushes to `main`.
 - Does not run `forge test` (no test files exist for these scripts).
 - Does not run signing or execution targets (they depend on network state and hardware wallets).
 
-> See
-> [`.github/workflows/validate-common-scripts.yml`](.github/workflows/validate-common-scripts.yml)
-> for the full workflow definition.
+> See [`.github/workflows/validate-common-scripts.yml`](.github/workflows/validate-common-scripts.yml) for the full workflow definition.
 
 ## Multisig macro convention
 
@@ -210,8 +192,7 @@ Task Makefiles use global macros defined in [`Multisig.mk`](Multisig.mk) for mul
 | `MULTISIG_EXECUTE` | Execute an approved transaction onchain                         | `(signatures)`                                            |
 | `GEN_VALIDATION`   | Generate a validation JSON file for signers via the signer-tool | `(script_name, safe_addr, sender, output_file, env_vars)` |
 
-Two helper macros are also available for tasks that need nonce offset calculations or address
-manipulation:
+Two helper macros are also available for tasks that need nonce offset calculations or address manipulation:
 
 | Macro        | Purpose                                                    | Key arguments    |
 | ------------ | ---------------------------------------------------------- | ---------------- |
@@ -220,8 +201,7 @@ manipulation:
 
 Signing is handled externally by the [task-signing-tool](https://github.com/base/task-signing-tool).
 
-Each task Makefile includes the root helpers, points Forge at the shared EVM project, and defines
-the RPC and script:
+Each task Makefile includes the root helpers, points Forge at the shared EVM project, and defines the RPC and script:
 
 ```makefile
 include ../../../../Makefile
@@ -233,22 +213,21 @@ RPC_URL := $(L1_RPC_URL)       # or $(L2_RPC_URL)
 SCRIPT_NAME := script/common/<category>/<script>.s.sol:<contract>
 ```
 
-Tasks that generate validation files should use `GEN_VALIDATION` with the `deps-signer-tool`
-prerequisite, which checks out and installs the signer tool:
+Tasks that generate validation files should use `GEN_VALIDATION` with the `deps-signer-tool` prerequisite, which checks out and installs the
+signer tool:
 
 ```makefile
 gen-validation: validate-config deps-signer-tool
 	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),base-signer.json,)
 ```
 
-Task Makefiles should use these macros rather than inline `forge script` or signer-tool invocations.
-A task that intentionally pre-signs several future nonces may keep its specialized `eip712sign` loop
-locally; approvals and execution should still use the shared macros.
+Task Makefiles should use these macros rather than inline `forge script` or signer-tool invocations. A task that intentionally pre-signs
+several future nonces may keep its specialized `eip712sign` loop locally; approvals and execution should still use the shared macros.
 
 ## Task origin signing
 
-The root Makefile provides three targets for generating cryptographic attestations that prove who
-created and facilitated a task. Active task Makefiles inherit them by including the root Makefile.
+The root Makefile provides three targets for generating cryptographic attestations that prove who created and facilitated a task. Active
+task Makefiles inherit them by including the root Makefile.
 
 | Target                          | Purpose                                         |
 | ------------------------------- | ----------------------------------------------- |
@@ -256,8 +235,8 @@ created and facilitated a task. Active task Makefiles inherit them by including 
 | `make sign-as-base-facilitator` | Attest Base team facilitation                   |
 | `make sign-as-sc-facilitator`   | Attest Security Council facilitation            |
 
-Legacy task Makefiles may use the root defaults below. Active task Makefiles override them so the
-task configuration is signed while signatures remain outside the signed payload:
+Legacy task Makefiles may use the root defaults below. Active task Makefiles override them so the task configuration is signed while
+signatures remain outside the signed payload:
 
 | Variable        | Default                                    | Description                           |
 | --------------- | ------------------------------------------ | ------------------------------------- |
@@ -267,8 +246,7 @@ task configuration is signed while signatures remain outside the signed payload:
 All three targets depend on `deps-signer-tool`, which checks out and installs the
 [task-signing-tool](https://github.com/base/task-signing-tool) automatically.
 
-For active EVM tasks, `TASK_ORIGIN_DIR` is `active/evm/tasks/<task-id>/config/<network>` and
-`SIGNATURE_DIR` is `active/evm/tasks/<task-id>/signatures/<network>`. Keeping signatures outside the
-config directory means generating them does not change the signed payload. Task-origin validation is
-required for mainnet scripts executed through the proxy admin owner. Other tasks, such as Zeronet
+For active EVM tasks, `TASK_ORIGIN_DIR` is `active/evm/tasks/<task-id>/config/<network>` and `SIGNATURE_DIR` is
+`active/evm/tasks/<task-id>/signatures/<network>`. Keeping signatures outside the config directory means generating them does not change the
+signed payload. Task-origin validation is required for mainnet scripts executed through the proxy admin owner. Other tasks, such as Zeronet
 tasks, may set `skipTaskOriginValidation: true` in each validation file.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 # contract-deployments
 
-This repo contains execution code and artifacts related to Base contract deployments, upgrades, and calls. For actual contract implementations, see [base/contracts](https://github.com/base/contracts).
+This repo contains execution code and artifacts related to Base contract deployments, upgrades, and
+calls. For actual contract implementations, see [base/contracts](https://github.com/base/contracts).
 
-Active EVM tasks live under `active/evm/tasks/`. Shared network configuration
-lives under `config/`, and completed historical tasks live under `archive/`.
+Active EVM tasks live under `active/evm/tasks/`. Shared network configuration lives under `config/`,
+and completed historical tasks live under `archive/`.
 
 <!-- Badge row 1 - status -->
 
@@ -32,15 +33,27 @@ lives under `config/`, and completed historical tasks live under `archive/`.
 
 ### Toolchain (mise)
 
-All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every contributor — and especially every signer — runs identical versions. This eliminates a class of bugs where domain separators, build artifacts, or generated signatures differ between machines.
+All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every
+contributor — and especially every signer — runs identical versions. This eliminates a class of bugs
+where domain separators, build artifacts, or generated signatures differ between machines.
 
-**Signers and facilitators don't need to install anything.** `make sign-task` (and `make deps`, `make execute`, etc.) automatically:
+**Signers and facilitators don't need to install anything.** `make sign-task` (and `make deps`,
+`make execute`, etc.) automatically:
 
-1. Installs [`mise`](https://mise.jdx.dev) to `~/.local/bin/mise` if it's not already present, using the vendored installer at [`scripts/install-mise.sh`](scripts/install-mise.sh).
-2. Trusts the repo's `mise.toml` and runs `mise install` to fetch the pinned `foundry`, `node`, `bun`, and `go` versions.
-3. Invokes every toolchain command through `mise exec --`, so the pinned versions are used without modifying your shell environment or `PATH`. This deliberately avoids conflicts with any existing `foundryup` or system-level installs.
+1. Installs [`mise`](https://mise.jdx.dev) to `~/.local/bin/mise` if it's not already present, using
+   the vendored installer at [`scripts/install-mise.sh`](scripts/install-mise.sh).
+2. Trusts the repo's `mise.toml` and runs `mise install` to fetch the pinned `foundry`, `node`,
+   `bun`, and `go` versions.
+3. Invokes every toolchain command through `mise exec --`, so the pinned versions are used without
+   modifying your shell environment or `PATH`. This deliberately avoids conflicts with any existing
+   `foundryup` or system-level installs.
 
-> **Important — `mise` must be on your PATH for the signer-tool.** The generated validation files contain a `cmd` field with `mise exec --` (deliberately, so the JSON is portable across machines), and the signer-tool re-executes that command in a fresh shell. If `mise` is not on your PATH, that subprocess will fail with "command not found". `make bootstrap-mise` will warn you if this is the case. To fix it, add this to your shell config (e.g. `~/.zshrc` or `~/.bashrc`) and restart your shell:
+> **Important — `mise` must be on your PATH for the signer-tool.** The generated validation files
+> contain a `cmd` field with `mise exec --` (deliberately, so the JSON is portable across machines),
+> and the signer-tool re-executes that command in a fresh shell. If `mise` is not on your PATH, that
+> subprocess will fail with "command not found". `make bootstrap-mise` will warn you if this is the
+> case. To fix it, add this to your shell config (e.g. `~/.zshrc` or `~/.bashrc`) and restart your
+> shell:
 >
 > ```bash
 > export PATH="$HOME/.local/bin:$PATH"
@@ -60,7 +73,8 @@ The `Commit SHA` is the source of truth — it must match the commit pinned in `
 
 #### For contributors authoring new tasks (optional)
 
-If you want bare `forge`/`cast`/`bun`/`go` invocations in your interactive shell to resolve to the pinned versions while you're working inside this repo, add mise's shell hook to your shell config:
+If you want bare `forge`/`cast`/`bun`/`go` invocations in your interactive shell to resolve to the
+pinned versions while you're working inside this repo, add mise's shell hook to your shell config:
 
 ```bash
 # zsh
@@ -73,8 +87,8 @@ This is purely a convenience for task authors — `make` targets work correctly 
 
 ### Running a task
 
-Each active task owns its Makefile, signer README, facilitator guide,
-configuration, and validations. Run task commands from the task directory:
+Each active task owns its Makefile, signer README, facilitator guide, configuration, and
+validations. Run task commands from the task directory:
 
 ```bash
 cd active/evm/tasks/<task-id>
@@ -82,33 +96,34 @@ make deps
 make <task-target>
 ```
 
-Signers run `make sign-task` from the repository root, select the network and
-task in the UI, and follow the task README.
+Signers run `make sign-task` from the repository root, select the network and task in the UI, and
+follow the task README.
 
 ## Network configuration
 
-Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and
-`config/zeronet.env`. Task Makefiles include the appropriate shared file and
-load operation-specific values from `config/<network>/.env` inside the task.
+Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and `config/zeronet.env`.
+Task Makefiles include the appropriate shared file and load operation-specific values from
+`config/<network>/.env` inside the task.
 
 The network `.env` files contain:
 
-- **Network metadata** — `NETWORK`, `L1_RPC_URL`, `L2_RPC_URL`, `L1_CHAIN_ID`, `L2_CHAIN_ID`, `LEDGER_ACCOUNT`
+- **Network metadata** — `NETWORK`, `L1_RPC_URL`, `L2_RPC_URL`, `L1_CHAIN_ID`, `L2_CHAIN_ID`,
+  `LEDGER_ACCOUNT`
 - **Admin addresses** — multisig addresses, proposer, challenger, batch sender, etc.
 - **L1 contract addresses** — proxy admin, bridges, dispute game factories, system config, etc.
 - **L2 contract addresses** — fee vaults, cross-domain messenger, standard bridge, etc.
 
-All address variables are prefixed with `export` so they are available to child shell processes (Forge scripts, shell commands, etc.). Foundry scripts can access them via `vm.envAddress("VARIABLE_NAME")`.
+All address variables are prefixed with `export` so they are available to child shell processes
+(Forge scripts, shell commands, etc.). Foundry scripts can access them via
+`vm.envAddress("VARIABLE_NAME")`.
 
-> **Note:** Update `config/<network>.env` when a known shared address changes.
-> Keep task-specific values, including `BASE_CONTRACTS_COMMIT`, in the task
-> `.env`.
+> **Note:** Update `config/<network>.env` when a known shared address changes. Keep task-specific
+> values, including `BASE_CONTRACTS_COMMIT`, in the task `.env`.
 
 ## Directory structure
 
-Active EVM tasks use one shared Foundry project. Dependencies and reusable
-Solidity are shared; Make targets, configuration, documentation, signatures,
-and execution records stay with each task:
+Active EVM tasks use one shared Foundry project. Dependencies and reusable Solidity are shared; Make
+targets, configuration, documentation, signatures, and execution records stay with each task:
 
 ```text
 active/evm/
@@ -131,13 +146,12 @@ active/evm/
         └── <script>/<chain-id>/ # Forge broadcast records after execution
 ```
 
-Task commands run from `active/evm/tasks/<task-id>`. The task Makefile installs
-dependencies and runs Forge against the shared `active/evm` project. Reusable
-scripts are documented in
+Task commands run from `active/evm/tasks/<task-id>`. The task Makefile installs dependencies and
+runs Forge against the shared `active/evm` project. Reusable scripts are documented in
 [`active/evm/script/common/README.md`](active/evm/script/common/README.md).
 
-To install dependencies for the shared project without selecting a task, invoke
-the root Makefile with a project directory and explicit commit:
+To install dependencies for the shared project without selecting a task, invoke the root Makefile
+with a project directory and explicit commit:
 
 ```bash
 make deps PROJECT_DIR="$PWD/active/evm" BASE_CONTRACTS_COMMIT=<commit>
@@ -149,23 +163,32 @@ Each task under `archive/legacy/<network>/` has a structure similar to:
 
 - **records/** Foundry will autogenerate files here from running commands
 - **script/** place to store any one-off Foundry scripts
-- **src/** place to store any one-off smart contracts (long-lived contracts should go in [base/contracts](https://github.com/base/contracts))
-- **.env** place to store task-specific environment variables (contract addresses are inherited from the network-level `.env`)
+- **src/** place to store any one-off smart contracts (long-lived contracts should go in
+  [base/contracts](https://github.com/base/contracts))
+- **.env** place to store task-specific environment variables (contract addresses are inherited from
+  the network-level `.env`)
 
 ## CI — Common Script Validation
 
-A GitHub Actions workflow automatically validates the shared `active/evm` scripts on every pull request and on pushes to `main`.
+A GitHub Actions workflow automatically validates the shared `active/evm` scripts on every pull
+request and on pushes to `main`.
 
 **What CI checks:**
 
 1. **Solidity formatting** — `forge fmt --check script/` ensures formatting consistency.
-2. **Compilation** — `forge build` verifies that imports resolve, types are correct, and all dependencies are present.
+2. **Compilation** — `forge build` verifies that imports resolve, types are correct, and all
+   dependencies are present.
 
 **How it works:**
 
-- All tooling (Foundry, Node, Bun, Go) is installed by the [`jdx/mise-action`](https://github.com/jdx/mise-action) GitHub Action using the versions pinned in [`mise.toml`](mise.toml), so CI matches local signer environments.
-- `make deps PROJECT_DIR="$PWD/active/evm"` installs dependencies into the shared `active/evm` Foundry project. `BASE_CONTRACTS_COMMIT` is supplied via the workflow's `env` block, since the shared project has no task `.env` of its own.
-- `forge fmt --check` and `forge build` then run in `active/evm` against the shared `foundry.toml` and `script/common/`.
+- All tooling (Foundry, Node, Bun, Go) is installed by the
+  [`jdx/mise-action`](https://github.com/jdx/mise-action) GitHub Action using the versions pinned in
+  [`mise.toml`](mise.toml), so CI matches local signer environments.
+- `make deps PROJECT_DIR="$PWD/active/evm"` installs dependencies into the shared `active/evm`
+  Foundry project. `BASE_CONTRACTS_COMMIT` is supplied via the workflow's `env` block, since the
+  shared project has no task `.env` of its own.
+- `forge fmt --check` and `forge build` then run in `active/evm` against the shared `foundry.toml`
+  and `script/common/`.
 
 **What CI does NOT do:**
 
@@ -173,7 +196,9 @@ A GitHub Actions workflow automatically validates the shared `active/evm` script
 - Does not run `forge test` (no test files exist for these scripts).
 - Does not run signing or execution targets (they depend on network state and hardware wallets).
 
-> See [`.github/workflows/validate-common-scripts.yml`](.github/workflows/validate-common-scripts.yml) for the full workflow definition.
+> See
+> [`.github/workflows/validate-common-scripts.yml`](.github/workflows/validate-common-scripts.yml)
+> for the full workflow definition.
 
 ## Multisig macro convention
 
@@ -185,7 +210,8 @@ Task Makefiles use global macros defined in [`Multisig.mk`](Multisig.mk) for mul
 | `MULTISIG_EXECUTE` | Execute an approved transaction onchain                         | `(signatures)`                                            |
 | `GEN_VALIDATION`   | Generate a validation JSON file for signers via the signer-tool | `(script_name, safe_addr, sender, output_file, env_vars)` |
 
-Two helper macros are also available for tasks that need nonce offset calculations or address manipulation:
+Two helper macros are also available for tasks that need nonce offset calculations or address
+manipulation:
 
 | Macro        | Purpose                                                    | Key arguments    |
 | ------------ | ---------------------------------------------------------- | ---------------- |
@@ -194,8 +220,8 @@ Two helper macros are also available for tasks that need nonce offset calculatio
 
 Signing is handled externally by the [task-signing-tool](https://github.com/base/task-signing-tool).
 
-Each task Makefile includes the root helpers, points Forge at the shared EVM
-project, and defines the RPC and script:
+Each task Makefile includes the root helpers, points Forge at the shared EVM project, and defines
+the RPC and script:
 
 ```makefile
 include ../../../../Makefile
@@ -207,24 +233,22 @@ RPC_URL := $(L1_RPC_URL)       # or $(L2_RPC_URL)
 SCRIPT_NAME := script/common/<category>/<script>.s.sol:<contract>
 ```
 
-Tasks that generate validation files should use `GEN_VALIDATION` with the
-`deps-signer-tool` prerequisite, which checks out and installs the signer tool:
+Tasks that generate validation files should use `GEN_VALIDATION` with the `deps-signer-tool`
+prerequisite, which checks out and installs the signer tool:
 
 ```makefile
 gen-validation: validate-config deps-signer-tool
 	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),base-signer.json,)
 ```
 
-Task Makefiles should use these macros rather than inline `forge script` or
-signer-tool invocations. A task that intentionally pre-signs several future
-nonces may keep its specialized `eip712sign` loop locally; approvals and
-execution should still use the shared macros.
+Task Makefiles should use these macros rather than inline `forge script` or signer-tool invocations.
+A task that intentionally pre-signs several future nonces may keep its specialized `eip712sign` loop
+locally; approvals and execution should still use the shared macros.
 
 ## Task origin signing
 
-The root Makefile provides three targets for generating cryptographic
-attestations that prove who created and facilitated a task. Active task
-Makefiles inherit them by including the root Makefile.
+The root Makefile provides three targets for generating cryptographic attestations that prove who
+created and facilitated a task. Active task Makefiles inherit them by including the root Makefile.
 
 | Target                          | Purpose                                         |
 | ------------------------------- | ----------------------------------------------- |
@@ -232,21 +256,19 @@ Makefiles inherit them by including the root Makefile.
 | `make sign-as-base-facilitator` | Attest Base team facilitation                   |
 | `make sign-as-sc-facilitator`   | Attest Security Council facilitation            |
 
-Legacy task Makefiles may use the root defaults below. Active task Makefiles
-override them so the task configuration is signed while signatures remain
-outside the signed payload:
+Legacy task Makefiles may use the root defaults below. Active task Makefiles override them so the
+task configuration is signed while signatures remain outside the signed payload:
 
 | Variable        | Default                                    | Description                           |
 | --------------- | ------------------------------------------ | ------------------------------------- |
 | `TASK_NAME`     | `$(notdir $(CURDIR))` (directory basename) | Name used to locate signature dir     |
 | `SIGNATURE_DIR` | `$(CURDIR)/../signatures/$(TASK_NAME)`     | Directory where signatures are stored |
 
-All three targets depend on `deps-signer-tool`, which checks out and installs the [task-signing-tool](https://github.com/base/task-signing-tool) automatically.
+All three targets depend on `deps-signer-tool`, which checks out and installs the
+[task-signing-tool](https://github.com/base/task-signing-tool) automatically.
 
-For active EVM tasks, `TASK_ORIGIN_DIR` is
-`active/evm/tasks/<task-id>/config/<network>` and `SIGNATURE_DIR` is
-`active/evm/tasks/<task-id>/signatures/<network>`. Keeping signatures outside
-the config directory means generating them does not change the signed payload.
-Task-origin validation is required for mainnet scripts executed through the
-proxy admin owner. Other tasks, such as Zeronet tasks, may set
-`skipTaskOriginValidation: true` in each validation file.
+For active EVM tasks, `TASK_ORIGIN_DIR` is `active/evm/tasks/<task-id>/config/<network>` and
+`SIGNATURE_DIR` is `active/evm/tasks/<task-id>/signatures/<network>`. Keeping signatures outside the
+config directory means generating them does not change the signed payload. Task-origin validation is
+required for mainnet scripts executed through the proxy admin owner. Other tasks, such as Zeronet
+tasks, may set `skipTaskOriginValidation: true` in each validation file.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 # contract-deployments
 
-This repo contains execution code and artifacts related to Base contract deployments, upgrades, and calls. For actual contract
-implementations, see [base/contracts](https://github.com/base/contracts).
+This repo contains execution code and artifacts related to Base contract deployments, upgrades, and calls. For actual contract implementations, see
+[base/contracts](https://github.com/base/contracts).
 
-Active EVM tasks live under `active/evm/tasks/`. Shared network configuration lives under `config/`, and completed historical tasks live
-under `archive/`.
+Active EVM tasks live under `active/evm/tasks/`. Shared network configuration lives under `config/`, and completed historical tasks live under `archive/`.
 
 <!-- Badge row 1 - status -->
 
@@ -19,8 +18,7 @@ under `archive/`.
 <!-- Badge row 2 - links and profiles -->
 
 [![Website base.org](https://img.shields.io/website-up-down-green-red/https/base.org.svg)](https://base.org)
-[![Blog](https://img.shields.io/badge/blog-up-green)](https://base.mirror.xyz/)
-[![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.base.org/)
+[![Blog](https://img.shields.io/badge/blog-up-green)](https://base.mirror.xyz/) [![Docs](https://img.shields.io/badge/docs-up-green)](https://docs.base.org/)
 [![Discord](https://img.shields.io/discord/1067165013397213286?label=discord)](https://base.org/discord)
 [![Twitter BuildOnBase](https://img.shields.io/twitter/follow/BuildOnBase?style=social)](https://x.com/BuildOnBase)
 
@@ -33,22 +31,19 @@ under `archive/`.
 
 ### Toolchain (mise)
 
-All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every contributor — and especially every
-signer — runs identical versions. This eliminates a class of bugs where domain separators, build artifacts, or generated signatures differ
-between machines.
+All required tooling (Foundry, Node.js, Bun, Go) is pinned in [`mise.toml`](mise.toml) so that every contributor — and especially every signer — runs identical versions. This
+eliminates a class of bugs where domain separators, build artifacts, or generated signatures differ between machines.
 
 **Signers and facilitators don't need to install anything.** `make sign-task` (and `make deps`, `make execute`, etc.) automatically:
 
-1. Installs [`mise`](https://mise.jdx.dev) to `~/.local/bin/mise` if it's not already present, using the vendored installer at
-   [`scripts/install-mise.sh`](scripts/install-mise.sh).
+1. Installs [`mise`](https://mise.jdx.dev) to `~/.local/bin/mise` if it's not already present, using the vendored installer at [`scripts/install-mise.sh`](scripts/install-mise.sh).
 2. Trusts the repo's `mise.toml` and runs `mise install` to fetch the pinned `foundry`, `node`, `bun`, and `go` versions.
-3. Invokes every toolchain command through `mise exec --`, so the pinned versions are used without modifying your shell environment or
-   `PATH`. This deliberately avoids conflicts with any existing `foundryup` or system-level installs.
+3. Invokes every toolchain command through `mise exec --`, so the pinned versions are used without modifying your shell environment or `PATH`. This deliberately avoids conflicts
+   with any existing `foundryup` or system-level installs.
 
-> **Important — `mise` must be on your PATH for the signer-tool.** The generated validation files contain a `cmd` field with `mise exec --`
-> (deliberately, so the JSON is portable across machines), and the signer-tool re-executes that command in a fresh shell. If `mise` is not
-> on your PATH, that subprocess will fail with "command not found". `make bootstrap-mise` will warn you if this is the case. To fix it, add
-> this to your shell config (e.g. `~/.zshrc` or `~/.bashrc`) and restart your shell:
+> **Important — `mise` must be on your PATH for the signer-tool.** The generated validation files contain a `cmd` field with `mise exec --` (deliberately, so the JSON is portable
+> across machines), and the signer-tool re-executes that command in a fresh shell. If `mise` is not on your PATH, that subprocess will fail with "command not found".
+> `make bootstrap-mise` will warn you if this is the case. To fix it, add this to your shell config (e.g. `~/.zshrc` or `~/.bashrc`) and restart your shell:
 >
 > ```bash
 > export PATH="$HOME/.local/bin:$PATH"
@@ -68,8 +63,8 @@ The `Commit SHA` is the source of truth — it must match the commit pinned in `
 
 #### For contributors authoring new tasks (optional)
 
-If you want bare `forge`/`cast`/`bun`/`go` invocations in your interactive shell to resolve to the pinned versions while you're working
-inside this repo, add mise's shell hook to your shell config:
+If you want bare `forge`/`cast`/`bun`/`go` invocations in your interactive shell to resolve to the pinned versions while you're working inside this repo, add mise's shell hook to
+your shell config:
 
 ```bash
 # zsh
@@ -82,8 +77,7 @@ This is purely a convenience for task authors — `make` targets work correctly 
 
 ### Running a task
 
-Each active task owns its Makefile, signer README, facilitator guide, configuration, and validations. Run task commands from the task
-directory:
+Each active task owns its Makefile, signer README, facilitator guide, configuration, and validations. Run task commands from the task directory:
 
 ```bash
 cd active/evm/tasks/<task-id>
@@ -95,8 +89,8 @@ Signers run `make sign-task` from the repository root, select the network and ta
 
 ## Network configuration
 
-Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and `config/zeronet.env`. Task Makefiles include the appropriate
-shared file and load operation-specific values from `config/<network>/.env` inside the task.
+Shared network values live in `config/mainnet.env`, `config/sepolia.env`, and `config/zeronet.env`. Task Makefiles include the appropriate shared file and load operation-specific
+values from `config/<network>/.env` inside the task.
 
 The network `.env` files contain:
 
@@ -105,16 +99,15 @@ The network `.env` files contain:
 - **L1 contract addresses** — proxy admin, bridges, dispute game factories, system config, etc.
 - **L2 contract addresses** — fee vaults, cross-domain messenger, standard bridge, etc.
 
-All address variables are prefixed with `export` so they are available to child shell processes (Forge scripts, shell commands, etc.).
-Foundry scripts can access them via `vm.envAddress("VARIABLE_NAME")`.
+All address variables are prefixed with `export` so they are available to child shell processes (Forge scripts, shell commands, etc.). Foundry scripts can access them via
+`vm.envAddress("VARIABLE_NAME")`.
 
-> **Note:** Update `config/<network>.env` when a known shared address changes. Keep task-specific values, including `BASE_CONTRACTS_COMMIT`,
-> in the task `.env`.
+> **Note:** Update `config/<network>.env` when a known shared address changes. Keep task-specific values, including `BASE_CONTRACTS_COMMIT`, in the task `.env`.
 
 ## Directory structure
 
-Active EVM tasks use one shared Foundry project. Dependencies and reusable Solidity are shared; Make targets, configuration, documentation,
-signatures, and execution records stay with each task:
+Active EVM tasks use one shared Foundry project. Dependencies and reusable Solidity are shared; Make targets, configuration, documentation, signatures, and execution records stay
+with each task:
 
 ```text
 active/evm/
@@ -137,11 +130,10 @@ active/evm/
         └── <script>/<chain-id>/ # Forge broadcast records after execution
 ```
 
-Task commands run from `active/evm/tasks/<task-id>`. The task Makefile installs dependencies and runs Forge against the shared `active/evm`
-project. Reusable scripts are documented in [`active/evm/script/common/README.md`](active/evm/script/common/README.md).
+Task commands run from `active/evm/tasks/<task-id>`. The task Makefile installs dependencies and runs Forge against the shared `active/evm` project. Reusable scripts are documented
+in [`active/evm/script/common/README.md`](active/evm/script/common/README.md).
 
-To install dependencies for the shared project without selecting a task, invoke the root Makefile with a project directory and explicit
-commit:
+To install dependencies for the shared project without selecting a task, invoke the root Makefile with a project directory and explicit commit:
 
 ```bash
 make deps PROJECT_DIR="$PWD/active/evm" BASE_CONTRACTS_COMMIT=<commit>
@@ -153,8 +145,7 @@ Each task under `archive/legacy/<network>/` has a structure similar to:
 
 - **records/** Foundry will autogenerate files here from running commands
 - **script/** place to store any one-off Foundry scripts
-- **src/** place to store any one-off smart contracts (long-lived contracts should go in
-  [base/contracts](https://github.com/base/contracts))
+- **src/** place to store any one-off smart contracts (long-lived contracts should go in [base/contracts](https://github.com/base/contracts))
 - **.env** place to store task-specific environment variables (contract addresses are inherited from the network-level `.env`)
 
 ## CI — Common Script Validation
@@ -168,10 +159,10 @@ A GitHub Actions workflow automatically validates the shared `active/evm` script
 
 **How it works:**
 
-- All tooling (Foundry, Node, Bun, Go) is installed by the [`jdx/mise-action`](https://github.com/jdx/mise-action) GitHub Action using the
-  versions pinned in [`mise.toml`](mise.toml), so CI matches local signer environments.
-- `make deps PROJECT_DIR="$PWD/active/evm"` installs dependencies into the shared `active/evm` Foundry project. `BASE_CONTRACTS_COMMIT` is
-  supplied via the workflow's `env` block, since the shared project has no task `.env` of its own.
+- All tooling (Foundry, Node, Bun, Go) is installed by the [`jdx/mise-action`](https://github.com/jdx/mise-action) GitHub Action using the versions pinned in
+  [`mise.toml`](mise.toml), so CI matches local signer environments.
+- `make deps PROJECT_DIR="$PWD/active/evm"` installs dependencies into the shared `active/evm` Foundry project. `BASE_CONTRACTS_COMMIT` is supplied via the workflow's `env` block,
+  since the shared project has no task `.env` of its own.
 - `forge fmt --check` and `forge build` then run in `active/evm` against the shared `foundry.toml` and `script/common/`.
 
 **What CI does NOT do:**
@@ -213,21 +204,20 @@ RPC_URL := $(L1_RPC_URL)       # or $(L2_RPC_URL)
 SCRIPT_NAME := script/common/<category>/<script>.s.sol:<contract>
 ```
 
-Tasks that generate validation files should use `GEN_VALIDATION` with the `deps-signer-tool` prerequisite, which checks out and installs the
-signer tool:
+Tasks that generate validation files should use `GEN_VALIDATION` with the `deps-signer-tool` prerequisite, which checks out and installs the signer tool:
 
 ```makefile
 gen-validation: validate-config deps-signer-tool
 	$(call GEN_VALIDATION,$(SCRIPT_NAME),,$(SENDER),base-signer.json,)
 ```
 
-Task Makefiles should use these macros rather than inline `forge script` or signer-tool invocations. A task that intentionally pre-signs
-several future nonces may keep its specialized `eip712sign` loop locally; approvals and execution should still use the shared macros.
+Task Makefiles should use these macros rather than inline `forge script` or signer-tool invocations. A task that intentionally pre-signs several future nonces may keep its
+specialized `eip712sign` loop locally; approvals and execution should still use the shared macros.
 
 ## Task origin signing
 
-The root Makefile provides three targets for generating cryptographic attestations that prove who created and facilitated a task. Active
-task Makefiles inherit them by including the root Makefile.
+The root Makefile provides three targets for generating cryptographic attestations that prove who created and facilitated a task. Active task Makefiles inherit them by including
+the root Makefile.
 
 | Target                          | Purpose                                         |
 | ------------------------------- | ----------------------------------------------- |
@@ -235,18 +225,15 @@ task Makefiles inherit them by including the root Makefile.
 | `make sign-as-base-facilitator` | Attest Base team facilitation                   |
 | `make sign-as-sc-facilitator`   | Attest Security Council facilitation            |
 
-Legacy task Makefiles may use the root defaults below. Active task Makefiles override them so the task configuration is signed while
-signatures remain outside the signed payload:
+Legacy task Makefiles may use the root defaults below. Active task Makefiles override them so the task configuration is signed while signatures remain outside the signed payload:
 
 | Variable        | Default                                    | Description                           |
 | --------------- | ------------------------------------------ | ------------------------------------- |
 | `TASK_NAME`     | `$(notdir $(CURDIR))` (directory basename) | Name used to locate signature dir     |
 | `SIGNATURE_DIR` | `$(CURDIR)/../signatures/$(TASK_NAME)`     | Directory where signatures are stored |
 
-All three targets depend on `deps-signer-tool`, which checks out and installs the
-[task-signing-tool](https://github.com/base/task-signing-tool) automatically.
+All three targets depend on `deps-signer-tool`, which checks out and installs the [task-signing-tool](https://github.com/base/task-signing-tool) automatically.
 
-For active EVM tasks, `TASK_ORIGIN_DIR` is `active/evm/tasks/<task-id>/config/<network>` and `SIGNATURE_DIR` is
-`active/evm/tasks/<task-id>/signatures/<network>`. Keeping signatures outside the config directory means generating them does not change the
-signed payload. Task-origin validation is required for mainnet scripts executed through the proxy admin owner. Other tasks, such as Zeronet
-tasks, may set `skipTaskOriginValidation: true` in each validation file.
+For active EVM tasks, `TASK_ORIGIN_DIR` is `active/evm/tasks/<task-id>/config/<network>` and `SIGNATURE_DIR` is `active/evm/tasks/<task-id>/signatures/<network>`. Keeping
+signatures outside the config directory means generating them does not change the signed payload. Task-origin validation is required for mainnet scripts executed through the proxy
+admin owner. Other tasks, such as Zeronet tasks, may set `skipTaskOriginValidation: true` in each validation file.


### PR DESCRIPTION
## What changed?

Updates the root README where the contract-ops reorganization made existing instructions incorrect:

- Replaces deleted `setup-*` commands with task-directory usage.
- Documents root `config/<network>.env` files and task-specific `.env` values.
- Retains a detailed, commented active-task directory tree.
- Preserves and updates the multisig macro tables, helper descriptions, Makefile example, and future-nonce exception.
- Preserves and updates task-origin targets, default variables, path rationale, and mainnet validation requirement.
- Removes only the obsolete walkthroughs for deleted setup templates; task signer READMEs and `FACILITATOR.md` files are now their source of truth.
- Keeps Markdown prose unwrapped and adds that convention to `AGENTS.md`.

## Checks

```bash
signer-tool/node_modules/.bin/prettier README.md --check --prose-wrap never --print-width 150
git diff --check
```
