### PR TITLE
Fix: Prevent accidental exposure of local deployment environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ out/
 yarn-error.log
 
 .env.local
+.env
+.env.*
 
 .gitmodules
 


### PR DESCRIPTION
### Description
This PR addresses future secret-file exposure risks within the `contract-deployments` repository.

**Vulnerabilities & Security Defects Remediated:**
* **Future Secret-File Exposure (`.gitignore`):** Local deployment environment files were not consistently ignored, creating a risk of accidentally committing sensitive configuration or deployment secrets. The repository's `.gitignore` policy has been updated to explicitly ignore `.env`, `.env.local`, and `.env.*` files. This ensures that any new local environment copies are safely untracked by default.